### PR TITLE
Map Profile from ProfileAndToken to Profile Resource

### DIFF
--- a/lib/Resource/BaseWorkOSResource.php
+++ b/lib/Resource/BaseWorkOSResource.php
@@ -80,6 +80,10 @@ class BaseWorkOSResource
             return $this->values[$key];
         }
 
+        if ($this->raw[$key]) {
+            return $this->raw[$key];
+        }
+
         $msg = "${key} does not exist on " . static::class;
         throw new \WorkOS\Exception\UnexpectedValueException($msg);
     }

--- a/lib/Resource/ProfileAndToken.php
+++ b/lib/Resource/ProfileAndToken.php
@@ -20,7 +20,7 @@ class ProfileAndToken extends BaseWorkOSResource
     {
         $instance = parent::constructFromResponse($response);
 
-        $instance->values["profile"] = $response["profile"];
+        $instance->values["profile"] = Profile::constructFromResponse($response["profile"]);
 
         return $instance;
     }

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -108,7 +108,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         $profileFixture = $this->profileFixture();
 
         $this->assertSame("01DMEK0J53CVMC32CK5SE0KZ8Q", $profileAndToken->accessToken);
-        $this->assertSame($profileFixture, $profileAndToken->profile);
+        $this->assertSame($profileFixture, $profileAndToken->profile->toArray());
     }
 
     public function testGetConnection()
@@ -228,13 +228,13 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         return [
             "id" => "prof_hen",
             "email" => "hen@papagenos.com",
-            "first_name" => "hen",
-            "last_name" => "cha",
-            "organization_id" => "org_01FG7HGMY2CZZR2FWHTEE94VF0",
-            "connection_id" => "conn_01EMH8WAK20T42N2NBMNBCYHAG",
-            "connection_type" => "GoogleOAuth",
-            "idp_id" => "randomalphanum",
-            "raw_attributes" => array(
+            "firstName" => "hen",
+            "lastName" => "cha",
+            "organizationId" => "org_01FG7HGMY2CZZR2FWHTEE94VF0",
+            "connectionId" => "conn_01EMH8WAK20T42N2NBMNBCYHAG",
+            "connectionType" => "GoogleOAuth",
+            "idpId" => "randomalphanum",
+            "rawAttributes" => array(
                 "email" => "hen@papagenos.com",
                 "first_name" => "hen",
                 "last_name" => "cha",


### PR DESCRIPTION
Currently the Profile returned in ProfileAndToken is not getting mapped to any resource, forcing users to operate on the values with snake_case instead of camelCase which differs from our other API responses. This will map the profile to the Profile Resource, and still allow the raw unmapped values to be returned as well. 