### PR TITLE
Expose `expires_at` in totp challenge responses

### DIFF
--- a/lib/Resource/AuthenticationChallengeTotp.php
+++ b/lib/Resource/AuthenticationChallengeTotp.php
@@ -14,6 +14,7 @@ class AuthenticationChallengeTotp extends BaseWorkOSResource
         "id",
         "createdAt",
         "updatedAt",
+        "expiresAt",
         "authenticationFactorId"
     ];
 
@@ -22,6 +23,7 @@ class AuthenticationChallengeTotp extends BaseWorkOSResource
         "id" => "id",
         "created_at" => "createdAt",
         "updated_at" => "updatedAt",
+        "expires_at" => "expiresAt",
         "authentication_factor_id" => "authenticationFactorId"
     ];
 }

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -141,8 +141,8 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             "before" => null,
             "after" => null,
             "domain" => null,
-            "organization_id" => null,
             "connection_type" => null,
+            "organization_id" => null,
             "order" => null
         ];
 

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -141,6 +141,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             "before" => null,
             "after" => null,
             "domain" => null,
+            "organization_id" => null,
             "connection_type" => null,
             "order" => null
         ];


### PR DESCRIPTION
Currently expires_at only indexed in SMS challenge responses. Adding to totp challenge responses to avoid a 'notice' being presented when the field is returned. Also adding unit test logic for PR https://github.com/workos/workos-php/pull/97