### PR TITLE
Uncover private methods in webhooks class

### DIFF
--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -38,7 +38,7 @@ class Webhook
      * @return boolean true
      */
 
-    private function verifyHeader($sigHeader, $payload, $secret, $tolerance)
+    public function verifyHeader($sigHeader, $payload, $secret, $tolerance)
     {
         $timestamp = (int)$this->getTimeStamp($sigHeader);
         $signature = $this->getSignature($sigHeader);
@@ -62,7 +62,7 @@ class Webhook
     * @return $timestamp
     */
 
-    private function getTimeStamp($sigHeader)
+    public function getTimeStamp($sigHeader)
     {
         $workosHeadersSplit = explode(',', $sigHeader, 2);
         $timestamp = substr($workosHeadersSplit[0], 2);
@@ -75,7 +75,7 @@ class Webhook
     * @return $signature
     */
 
-    private function getSignature($sigHeader)
+    public function getSignature($sigHeader)
     {
         $workosHeadersSplit = explode(',', $sigHeader, 2);
         $signature = substr($workosHeadersSplit[1], 4);

--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -23,9 +23,10 @@ class Webhook
         $eventResult = $this->verifyHeader($sigHeader, $payload, $secret, $tolerance);
 
         if ($eventResult == "pass"):
-            return Resource\Webhook::constructFromPayload($payload); else:
-                return $eventResult;
-            endif;
+            return Resource\Webhook::constructFromPayload($payload);
+        else:
+            return $eventResult;
+        endif;
     }
 
     /**
@@ -48,12 +49,16 @@ class Webhook
         $expectedSignature = hash_hmac("sha256", $signedPayload, $secret, false);
 
         if (empty($timestamp)):
-            return "No Timestamp available"; elseif (empty($signature)):
-                return "No signature hash found with expected scheme v1"; elseif ($timestamp < $currentTime - $tolerance):
-                    return "Timestamp outside of tolerance"; elseif ($signature != $expectedSignature):
-                        return "Constructed signature " . $expectedSignature . "Does not match WorkOS Header Signature " . $signature; else:
-                            return "pass";
-                        endif;
+            return "No Timestamp available";
+        elseif (empty($signature)):
+            return "No signature hash found with expected scheme v1";
+        elseif ($timestamp < $currentTime - $tolerance):
+            return "Timestamp outside of tolerance";
+        elseif ($signature != $expectedSignature):
+            return "Constructed signature " . $expectedSignature . "Does not match WorkOS Header Signature " . $signature;
+        else:
+            return "pass";
+        endif;
     }
 
     /**
@@ -64,7 +69,7 @@ class Webhook
 
     public function getTimeStamp($sigHeader)
     {
-        $workosHeadersSplit = explode(',', $sigHeader, 2);
+        $workosHeadersSplit = explode(",", $sigHeader, 2);
         $timestamp = substr($workosHeadersSplit[0], 2);
         return $timestamp;
     }
@@ -77,7 +82,7 @@ class Webhook
 
     public function getSignature($sigHeader)
     {
-        $workosHeadersSplit = explode(',', $sigHeader, 2);
+        $workosHeadersSplit = explode(",", $sigHeader, 2);
         $signature = substr($workosHeadersSplit[1], 4);
         return $signature;
     }

--- a/tests/WorkOS/WebhookTest.php
+++ b/tests/WorkOS/WebhookTest.php
@@ -14,24 +14,49 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 
         $this->withApiKey();
         $this->ap = new Webhook();
+
+        $this->payload = '{"id":"wh_01FGCG6SDYCT5XWZT9CDW0XEB8","data":{"id":"conn_01EHWNC0FCBHZ3BJ7EGKYXK0E6","name":"Foo Corp\'s Connection","state":"active","object":"connection","domains":[{"id":"conn_domain_01EHWNFTAFCF3CQAE5A9Q0P1YB","domain":"foo-corp.com","object":"connection_domain"}],"connection_type":"OktaSAML","organization_id":"org_01EHWNCE74X7JSDV0X3SZ3KJNY"},"event":"connection.activated"}';
+        $this->secret = 'secret';
+        $this->tolerance = 180;
+        $this->time = time();
+        $decodedBody = utf8_decode($this->payload);
+        $signedPayload = $this->time . "." . $decodedBody;
+        $this->expectedSignature = hash_hmac("sha256", $signedPayload, $this->secret, false);
+        $this->sigHeader = 't=' . $this->time . ', v1=' . $this->expectedSignature;
     }
 
     public function testConstructEventWebhook()
     {
-        $time = time();
-        $payload = '{"id":"wh_01FGCG6SDYCT5XWZT9CDW0XEB8","data":{"id":"conn_01EHWNC0FCBHZ3BJ7EGKYXK0E6","name":"Foo Corp\'s Connection","state":"active","object":"connection","domains":[{"id":"conn_domain_01EHWNFTAFCF3CQAE5A9Q0P1YB","domain":"foo-corp.com","object":"connection_domain"}],"connection_type":"OktaSAML","organization_id":"org_01EHWNCE74X7JSDV0X3SZ3KJNY"},"event":"connection.activated"}';
-        $secret = 'secret';
-        $tolerance = 180;
-        $decodedBody = utf8_decode($payload);
-        $signedPayload = $time . "." . $decodedBody;
-        $expectedSignature = hash_hmac("sha256", $signedPayload, $secret, false);
-        $headers = 't=' . $time . ', v1=' . $expectedSignature;
         $result = $this->generateConnectionFixture();
 
-        $expectation = '{"id":"wh_01FGCG6SDYCT5XWZT9CDW0XEB8","data":{"id":"conn_01EHWNC0FCBHZ3BJ7EGKYXK0E6","name":"Foo Corp\'s Connection","state":"active","object":"connection","domains":[{"id":"conn_domain_01EHWNFTAFCF3CQAE5A9Q0P1YB","domain":"foo-corp.com","object":"connection_domain"}],"connection_type":"OktaSAML","organization_id":"org_01EHWNCE74X7JSDV0X3SZ3KJNY"},"event":"connection.activated"}';
+        $expectation = $this->payload;
 
-        $response = $this->ap->constructEvent($headers, $payload, $secret, $tolerance);
+        $response = $this->ap->constructEvent($this->sigHeader, $this->payload, $this->secret, $this->tolerance);
         $this->assertSame($expectation, json_encode($response));
+    }
+
+    public function testVerifyHeaderWebhook()
+    {
+        $expectation = 'pass';
+
+        $response = $this->ap->verifyHeader($this->sigHeader, $this->payload, $this->secret, $this->tolerance);
+        $this->assertSame($expectation, $response);
+    }
+
+    public function testGetTimeStamp()
+    {
+        $expectation = strval($this->time);
+
+        $response = $this->ap->getTimeStamp($this->sigHeader);
+        $this->assertSame($expectation, $response);
+    }
+
+    public function testGetSignature()
+    {
+        $expectation = $this->expectedSignature;
+
+        $response = $this->ap->getSignature($this->sigHeader);
+        $this->assertSame($expectation, $response);
     }
 
     // Fixtures


### PR DESCRIPTION
In addition to the previous public method in the Webhooks class, constructEvent, we also uncover the private methods in this class:

verifyHeader
getTimestamp
getSignature

Followed Ruby PR as an example: https://github.com/workos/workos-ruby/pull/171