### PR TITLE
Display error and error_description in error handling

### DIFF
--- a/lib/Exception/BaseRequestException.php
+++ b/lib/Exception/BaseRequestException.php
@@ -36,10 +36,10 @@ class BaseRequestException extends \Exception
             $this->responseErrors = $responseJson["errors"];
         }
         if (!empty($responseJson["code"])) {
-            $this->responseErrors = $responseJson["code"];
+            $this->responseCode = $responseJson["code"];
         }
         if (!empty($responseJson["message"])) {
-            $this->responseErrors = $responseJson["message"];
+            $this->responseMessage = $responseJson["message"];
         }
 
         $this->filterResponseForException($response);

--- a/lib/Exception/BaseRequestException.php
+++ b/lib/Exception/BaseRequestException.php
@@ -30,7 +30,7 @@ class BaseRequestException extends \Exception
     {
         try {
             $responseJson = $response->json();
-            $this->message = $responseJson["message"];
+            $this->message = $responseJson["error"] . ": " . $responseJson["error_description"];
         } catch (\Exception $e) {
             $this->message = "";
         }

--- a/lib/Exception/BaseRequestException.php
+++ b/lib/Exception/BaseRequestException.php
@@ -10,6 +10,11 @@ namespace WorkOS\Exception;
 class BaseRequestException extends \Exception
 {
     public $requestId = "";
+    public $responseError;
+    public $responseErrorDescription;
+    public $responseErrors;
+    public $responseCode;
+    public $responseMessage;
 
     /**
      * BaseRequestException constructor.
@@ -19,6 +24,24 @@ class BaseRequestException extends \Exception
      */
     public function __construct($response, $message = null)
     {
+        $responseJson = $response->json();
+
+        if (!empty($responseJson["error"])) {
+            $this->responseError = $responseJson["error"];
+        }
+        if (!empty($responseJson["error_description"])) {
+            $this->responseErrorDescription = $responseJson["error_description"];
+        }
+        if (!empty($responseJson["errors"])) {
+            $this->responseErrors = $responseJson["errors"];
+        }
+        if (!empty($responseJson["code"])) {
+            $this->responseErrors = $responseJson["code"];
+        }
+        if (!empty($responseJson["message"])) {
+            $this->responseErrors = $responseJson["message"];
+        }
+
         $this->filterResponseForException($response);
 
         if (isset($message)) {
@@ -29,8 +52,9 @@ class BaseRequestException extends \Exception
     private function filterResponseForException($response)
     {
         try {
-            $responseJson = $response->json();
-            $this->message = $responseJson["error"] . ": " . $responseJson["error_description"];
+            $responseBody = $response->body;
+
+            $this->message = $responseBody;
         } catch (\Exception $e) {
             $this->message = "";
         }

--- a/tests/WorkOS/ClientTest.php
+++ b/tests/WorkOS/ClientTest.php
@@ -89,6 +89,95 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+      /**
+     * @dataProvider requestExceptionTestProvider
+     */
+    public function testClientThrowsRequestExceptionsWithBadMessageAndCode($statusCode, $exceptionClass)
+    {
+        $this->withApiKeyAndClientId();
+
+        $path = "some/place";
+        $result = $this->messageAndCodeFixture();
+
+        $this->mockRequest(
+            Client::METHOD_GET,
+            $path,
+            null,
+            null,
+            false,
+            $result,
+            null,
+            $statusCode
+        );
+
+        try {
+            Client::request(Client::METHOD_GET, $path);
+        } catch (Exception\BaseRequestException $e) {
+            // var_dump($e);
+            $this->assertEquals($e->responseMessage, "Start date cannot be before 2022-06-22T00:00:00.000Z.");
+            $this->assertEquals($e->responseCode, "invalid_date_range_exception");
+        }
+    }
+
+     /**
+     * @dataProvider requestExceptionTestProvider
+     */
+    public function testClientThrowsRequestExceptionsWithErrorAndErrorDescription($statusCode, $exceptionClass)
+    {
+        $this->withApiKeyAndClientId();
+
+        $path = "some/place";
+        $result = $this->errorAndErrorDescriptionFixture();
+
+        $this->mockRequest(
+            Client::METHOD_GET,
+            $path,
+            null,
+            null,
+            false,
+            $result,
+            null,
+            $statusCode
+        );
+
+        try {
+            Client::request(Client::METHOD_GET, $path);
+        } catch (Exception\BaseRequestException $e) {
+            // var_dump($e);
+            $this->assertEquals($e->responseError, "invalid_grant");
+            $this->assertEquals($e->responseErrorDescription, "The code '01GDK892VGKGVF2QNWVTABG8MX' has expired or is invalid.");
+        }
+    }
+
+       /**
+     * @dataProvider requestExceptionTestProvider
+     */
+    public function testClientThrowsRequestExceptionsWithErrors($statusCode, $exceptionClass)
+    {
+        $this->withApiKeyAndClientId();
+
+        $path = "some/place";
+        $result = $this->errorsDescriptionFixture();
+
+        $this->mockRequest(
+            Client::METHOD_GET,
+            $path,
+            null,
+            null,
+            false,
+            $result,
+            null,
+            $statusCode
+        );
+
+        try {
+            Client::request(Client::METHOD_GET, $path);
+        } catch (Exception\BaseRequestException $e) {
+            // var_dump($e);
+            $this->assertEquals($e->responseErrors, ["invalid_grant", "ambiguous_connection_selector"]);
+        }
+    }
+
     // Providers
     public function requestExceptionTestProvider()
     {
@@ -101,5 +190,28 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             [503, Exception\ServerException::class],
             [504, Exception\ServerException::class]
         ];
+    }
+
+    private function messageAndCodeFixture()
+    {
+        return json_encode([
+            "message" => "Start date cannot be before 2022-06-22T00:00:00.000Z.",
+            "code" => "invalid_date_range_exception"
+        ]);
+    }
+
+    private function errorAndErrorDescriptionFixture()
+    {
+        return json_encode([
+            "error" => "invalid_grant",
+            "error_description" => "The code '01GDK892VGKGVF2QNWVTABG8MX' has expired or is invalid."
+        ]);
+    }
+
+    private function errorsDescriptionFixture()
+    {
+        return json_encode([
+            "errors" => ["invalid_grant", "ambiguous_connection_selector"]
+        ]);
     }
 }

--- a/tests/WorkOS/ClientTest.php
+++ b/tests/WorkOS/ClientTest.php
@@ -85,7 +85,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         try {
             Client::request(Client::METHOD_GET, $path);
         } catch (Exception\BaseRequestException $e) {
-            $this->assertEquals($e->getMessage(), "");
+            $this->assertEquals($e->getMessage(), $result);
         }
     }
 

--- a/tests/WorkOS/ClientTest.php
+++ b/tests/WorkOS/ClientTest.php
@@ -92,7 +92,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
       /**
      * @dataProvider requestExceptionTestProvider
      */
-    public function testClientThrowsRequestExceptionsWithBadMessageAndCode($statusCode, $exceptionClass)
+    public function testClientThrowsRequestExceptionsWithMessageAndCode($statusCode, $exceptionClass)
     {
         $this->withApiKeyAndClientId();
 
@@ -157,7 +157,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $this->withApiKeyAndClientId();
 
         $path = "some/place";
-        $result = $this->errorsDescriptionFixture();
+        $result = $this->errorsArrayFixture();
 
         $this->mockRequest(
             Client::METHOD_GET,
@@ -208,7 +208,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    private function errorsDescriptionFixture()
+    private function errorsArrayFixture()
     {
         return json_encode([
             "errors" => ["invalid_grant", "ambiguous_connection_selector"]


### PR DESCRIPTION
Fixes https://github.com/workos/workos-php/issues/108

Encountering an error in the API generates: 
 `'Undefined index: message' from /var/www/api/v1/vendor/workos/workos-php/lib/Exception/BaseRequestException.php:33`

This could be a notice, warn, or error depending on PHP version and framework. 

Additionally the error returned is not informative:
`Uncaught WorkOS\Exception\BadRequestException in /Users/svaughn/Documents/php-example-applications/php-sso-example/vendor/workos/workos-php/lib/Client.php:77`

**This is because of the previous line of code:**
`$this->message = $responseJson["message"];`

**tries to reference a 'message' field on the API response, which does not exist (possibly did at some point?).** 

This PR will remove the undefined index, and return a more informative error message such as: 
`Uncaught WorkOS\Exception\BadRequestException: invalid_grant: The code '01GDGNTCJ87GDTEWX7MTZ4A77H' has expired or is invalid.`