### PR TITLE
Remove default null on domain in getAuthorizationUrl

### DIFF
--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -24,7 +24,7 @@ class SSO
      * @return string
      */
     public function getAuthorizationUrl(
-        $domain = null,
+        $domain,
         $redirectUri,
         $state,
         $provider = null,


### PR DESCRIPTION
Resolves https://github.com/workos/workos-php/issues/124 by removing default NULL value from domain on getAuthorizationUrl function based on suggestion https://php.watch/versions/8.0/deprecate-required-param-after-optional 