### PR TITLE
Major Release Version Bump to v2.0.0

### DIFF
--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS;
 final class Version
 {
     public const SDK_IDENTIFIER = "WorkOS PHP";
-    public const SDK_VERSION = '1.19.0';
+    public const SDK_VERSION = '2.0.0';
 }


### PR DESCRIPTION
A major release version bump for https://github.com/workos/workos-php/commit/99fd091ea11a5f143880a09f09c6d072fa67fb68

## Description
Bump to version v2.0.0
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
