### PR TITLE
Avoid PHP 8.2 deprecation

### DIFF
--- a/lib/AuditLogs.php
+++ b/lib/AuditLogs.php
@@ -102,7 +102,7 @@ class AuditLogs
 
     public function getExport($auditLogExportId)
     {
-        $getExportPath = "audit_logs/exports/${auditLogExportId}";
+        $getExportPath = "audit_logs/exports/{$auditLogExportId}";
 
         $response = Client::request(Client::METHOD_GET, $getExportPath, null, null, true);
 

--- a/lib/AuditTrail.php
+++ b/lib/AuditTrail.php
@@ -50,7 +50,7 @@ class AuditTrail
 
         $headers = null;
         if ($idempotencyKey) {
-            $headers = ["idempotency-key: ${idempotencyKey}"];
+            $headers = ["idempotency-key: {$idempotencyKey}"];
         }
 
         Client::request(Client::METHOD_POST, $eventsPath, $headers, $event, true);

--- a/lib/DirectorySync.php
+++ b/lib/DirectorySync.php
@@ -128,7 +128,7 @@ class DirectorySync
      */
     public function getGroup($directoryGroup)
     {
-        $groupPath = "directory_groups/${directoryGroup}";
+        $groupPath = "directory_groups/{$directoryGroup}";
 
         $response = Client::request(
             Client::METHOD_GET,
@@ -205,7 +205,7 @@ class DirectorySync
      */
     public function getUser($directoryUser)
     {
-        $userPath = "directory_users/${directoryUser}";
+        $userPath = "directory_users/{$directoryUser}";
 
         $response = Client::request(
             Client::METHOD_GET,
@@ -227,7 +227,7 @@ class DirectorySync
      */
     public function deleteDirectory($directory)
     {
-        $directoryPath = "directories/${directory}";
+        $directoryPath = "directories/{$directory}";
 
         $response = Client::request(
             Client::METHOD_DELETE,
@@ -250,7 +250,7 @@ class DirectorySync
 
     public function getDirectory($directory)
     {
-        $directoriesPath = "directories/${directory}";
+        $directoriesPath = "directories/{$directory}";
 
         $response = Client::request(Client::METHOD_GET, $directoriesPath, null, null, true);
 

--- a/lib/MFA.php
+++ b/lib/MFA.php
@@ -177,7 +177,7 @@ class MFA
 
     public function getFactor($authenticationFactorId)
     {
-        $getFactorPath = "auth/factors/${authenticationFactorId}";
+        $getFactorPath = "auth/factors/{$authenticationFactorId}";
 
         $response = Client::request(
             Client::METHOD_GET,
@@ -199,7 +199,7 @@ class MFA
 
     public function deleteFactor($authenticationFactorId)
     {
-        $deleteFactorPath = "auth/factors/${authenticationFactorId}";
+        $deleteFactorPath = "auth/factors/{$authenticationFactorId}";
 
         $response = Client::request(
             Client::METHOD_DELETE,

--- a/lib/Organizations.php
+++ b/lib/Organizations.php
@@ -120,7 +120,7 @@ class Organizations
 
     public function getOrganization($organization)
     {
-        $organizationsPath = "organizations/${organization}";
+        $organizationsPath = "organizations/{$organization}";
 
         $response = Client::request(Client::METHOD_GET, $organizationsPath, null, null, true);
 
@@ -136,7 +136,7 @@ class Organizations
      */
     public function deleteOrganization($organization)
     {
-        $organizationsPath = "organizations/${organization}";
+        $organizationsPath = "organizations/{$organization}";
 
         $response = Client::request(
             Client::METHOD_DELETE,

--- a/lib/Resource/BaseWorkOSResource.php
+++ b/lib/Resource/BaseWorkOSResource.php
@@ -60,7 +60,7 @@ class BaseWorkOSResource
             $this->values[$key] = $value;
         }
 
-        $msg = "${key} does not exist on " . static::class;
+        $msg = "{$key} does not exist on " . static::class;
         throw new \WorkOS\Exception\UnexpectedValueException($msg);
     }
 
@@ -84,7 +84,7 @@ class BaseWorkOSResource
             return $this->raw[$key];
         }
 
-        $msg = "${key} does not exist on " . static::class;
+        $msg = "{$key} does not exist on " . static::class;
         throw new \WorkOS\Exception\UnexpectedValueException($msg);
     }
 }

--- a/lib/Resource/Profile.php
+++ b/lib/Resource/Profile.php
@@ -4,6 +4,16 @@ namespace WorkOS\Resource;
 
 /**
  * Class Profile.
+ *
+ * @property string $id
+ * @property string $email
+ * @property string $firstName
+ * @property string $lastName
+ * @property string $organizationId
+ * @property string $connectionId
+ * @property string $connectionType
+ * @property string $idpId
+ * @property array  $rawAttributes
  */
 class Profile extends BaseWorkOSResource
 {

--- a/lib/Resource/ProfileAndToken.php
+++ b/lib/Resource/ProfileAndToken.php
@@ -4,6 +4,9 @@ namespace WorkOS\Resource;
 
 /**
  * Class ProfileAndToken.
+ *
+ * @property string  $accessToken
+ * @property Profile $profile
  */
 class ProfileAndToken extends BaseWorkOSResource
 {

--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -151,7 +151,7 @@ class SSO
      */
     public function deleteConnection($connection)
     {
-        $connectionPath = "connections/${connection}";
+        $connectionPath = "connections/{$connection}";
 
         $response = Client::request(
             Client::METHOD_DELETE,
@@ -173,7 +173,7 @@ class SSO
      */
     public function getConnection($connection)
     {
-        $connectionPath = "connections/${connection}";
+        $connectionPath = "connections/{$connection}";
 
         $response = Client::request(
             Client::METHOD_GET,


### PR DESCRIPTION
## Description

Hi @jonatascastro12, @sheldonvaughn, @hadihallak

Cf https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation
The `${foo}` syntax is deprecated in PHP 8.2 and should be replaced by `{$foo}`.

I also added `@property` annotation to `Profile` and `ProfileAndToken` classes in order to have autocompletion from PHPStorm or for static analysis tools like PHPStan. This way, both understand the syntax:
```
$profileAndToken->profile->email
```

## Documentation

No Need to update the doc.
