### PR TITLE
Add groups attribute to SSO user profile

### DIFF
--- a/lib/Resource/Profile.php
+++ b/lib/Resource/Profile.php
@@ -13,6 +13,7 @@ namespace WorkOS\Resource;
  * @property string $connectionId
  * @property string $connectionType
  * @property string $idpId
+ * @property array  $groups
  * @property array  $rawAttributes
  */
 class Profile extends BaseWorkOSResource
@@ -28,6 +29,7 @@ class Profile extends BaseWorkOSResource
         "connectionId",
         "connectionType",
         "idpId",
+        "groups",
         "rawAttributes"
     ];
 
@@ -40,6 +42,7 @@ class Profile extends BaseWorkOSResource
         "connection_id" => "connectionId",
         "connection_type" => "connectionType",
         "idp_id" => "idpId",
+        "groups" => "groups",
         "raw_attributes" => "rawAttributes"
     ];
 }

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -215,11 +215,13 @@ class SSOTest extends \PHPUnit\Framework\TestCase
                 "connection_id" => "conn_01EMH8WAK20T42N2NBMNBCYHAG",
                 "connection_type" => "GoogleOAuth",
                 "idp_id" => "randomalphanum",
+                "groups" => array("Admins", "Developers"),
                 "raw_attributes" => array(
                     "email" => "hen@papagenos.com",
                     "first_name" => "hen",
                     "last_name" => "cha",
-                    "ipd_id" => "randomalphanum"
+                    "ipd_id" => "randomalphanum",
+                    "groups" => array("Admins", "Developers")
                 )
             ]
         ]);
@@ -236,11 +238,13 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             "connectionId" => "conn_01EMH8WAK20T42N2NBMNBCYHAG",
             "connectionType" => "GoogleOAuth",
             "idpId" => "randomalphanum",
+            "groups" => array("Admins", "Developers"),
             "rawAttributes" => array(
                 "email" => "hen@papagenos.com",
                 "first_name" => "hen",
                 "last_name" => "cha",
                 "ipd_id" => "randomalphanum"
+                "groups" => array("Admins", "Developers")
             )
         ];
     }

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -243,7 +243,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
                 "email" => "hen@papagenos.com",
                 "first_name" => "hen",
                 "last_name" => "cha",
-                "ipd_id" => "randomalphanum"
+                "ipd_id" => "randomalphanum",
                 "groups" => array("Admins", "Developers")
             )
         ];


### PR DESCRIPTION
## Description

Add groups attribute to SSO user profile

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
