### PR TITLE
Fix ConnectionType usage in phpdoc

### DIFF
--- a/lib/Passwordless.php
+++ b/lib/Passwordless.php
@@ -15,10 +15,12 @@ class Passwordless
      * @param string $email Email address of the user that the session is to be created for
      * @param null|string $redirectURI URI to direct the user to user to upon authenticating through the passwordless link
      * @param null|string $state Encoded string used to manage application state
-     * @param \WorkOS\Resource\ConnectionType $type The only supported ConnectionType at the time of this writing is MagicLink
+     * @param string $type The only supported ConnectionType at the time of this writing is MagicLink
      * @param $connection the unique WorkOS connection_ID
      * @param $expiresIn The number of seconds the Passwordless Session should live before expiring.
      * @return  \WorkOS\Resource\PasswordlessSession
+     *
+     * @phpstan-param \WorkOS\Resource\ConnectionType::* $type
      */
     public function createSession($email, $redirectUri, $state, $type, $connection, $expiresIn)
     {

--- a/lib/Passwordless.php
+++ b/lib/Passwordless.php
@@ -19,8 +19,6 @@ class Passwordless
      * @param $connection the unique WorkOS connection_ID
      * @param $expiresIn The number of seconds the Passwordless Session should live before expiring.
      * @return  \WorkOS\Resource\PasswordlessSession
-     *
-     * @phpstan-param \WorkOS\Resource\ConnectionType::* $type
      */
     public function createSession($email, $redirectUri, $state, $type, $connection, $expiresIn)
     {

--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -15,13 +15,15 @@ class SSO
      * @param null|string $domain Domain of the user that will be going through SSO
      * @param null|string $redirectUri URI to direct the user to upon successful completion of SSO
      * @param null|array $state Associative array containing state that will be returned from WorkOS as a json encoded string
-     * @param null|\WorkOS\Resource\ConnectionType $provider Service provider that handles the identity of the user
+     * @param null|string $provider Service provider that handles the identity of the user
      * @param null|string $connection Unique identifier for a WorkOS Connection
      * @param null|string $organization Unique identifier for a WorkOS Organization
      * @param null|string $domainHint DDomain hint that will be passed as a parameter to the IdP login page
      * @param null|string $loginHint Username/email hint that will be passed as a parameter to the to IdP login page
      *
      * @return string
+     *
+     * @phpstan-param null|\WorkOS\Resource\ConnectionType::* $provider
      */
     public function getAuthorizationUrl(
         $domain,
@@ -192,7 +194,7 @@ class SSO
      * List Connections.
      *
      * @param null|string $domain Domain of a Connection
-     * @param null|\WorkOS\Resource\ConnectionType $connectionType Authentication service provider descriptor
+     * @param null|string $connectionType Authentication service provider descriptor
      * @param null|string $organizationId Organization ID of the Connection(s)
      * @param int $limit Maximum number of records to return
      * @param null|string $before Connection ID to look before
@@ -203,6 +205,8 @@ class SSO
      *      null|string Connection ID to use as before cursor
      *      null|string Connection ID to use as after cursor
      *      array \WorkOS\Resource\Connection instances
+     *
+     * @phpstan-param null|\WorkOS\Resource\ConnectionType::* $connectionType
      */
     public function listConnections(
         $domain = null,

--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -22,8 +22,6 @@ class SSO
      * @param null|string $loginHint Username/email hint that will be passed as a parameter to the to IdP login page
      *
      * @return string
-     *
-     * @phpstan-param null|\WorkOS\Resource\ConnectionType::* $provider
      */
     public function getAuthorizationUrl(
         $domain,
@@ -205,8 +203,6 @@ class SSO
      *      null|string Connection ID to use as before cursor
      *      null|string Connection ID to use as after cursor
      *      array \WorkOS\Resource\Connection instances
-     *
-     * @phpstan-param null|\WorkOS\Resource\ConnectionType::* $connectionType
      */
     public function listConnections(
         $domain = null,


### PR DESCRIPTION
## Description

Hi, @sheldonvaughn 

When a connectionType is expected, the phpdoc is saying
```
 @param null|\WorkOS\Resource\ConnectionType $provider
```
but this phpdoc is not correct:
- ConnectionType means the object connectionType, like `new ConnectionType()`
- a string is expected, like the constant `ConnectionType::GoogleOAuth`

You're kinda using the phpdoc like it was an enum but it's still a class. But some tool are understanding the syntax `ConnectionType::*` as "Any constant of the following class", this is the case of PHPStorm and PHPStan.
I fixed the phpdoc to `null|string` and added the special phpdoc with a `phpstan-` prefix.

I can remove the `phpstan` phpdoc if not wanted but, at least 
```
 @param null|\WorkOS\Resource\ConnectionType
```
need to be fixed to
```
 @param null|string
```