### PR TITLE
Add throws tag to every methods

### DIFF
--- a/lib/AuditLogs.php
+++ b/lib/AuditLogs.php
@@ -35,6 +35,8 @@ class AuditLogs
             * array "metadata" Arbitrary key-value data containing information associated with the event. NOT REQUIRED
      * @param string $idempotencyKey Unique key guaranteeing idempotency of events for 24 hours.
      *
+     * @throws Exception\WorkOSException
+     *
      * @return  \WorkOS\Resource\AuditLogCreateEventStatus
      */
 
@@ -58,14 +60,16 @@ class AuditLogs
 
     /**
      * @param array $auditLogExportOptions Associative array containing the keys detailed below
-        * @var null|string $organizationId Description of the record.
-        * @var null|string $rangeStart ISO-8601 Timestamp of the start of Export's the date range.
-        * @var null|string $rangeEnd ISO-8601 Timestamp  of the end of Export's the date range.
-        * @var null|array $actions Actions that Audit Log Events will be filtered by.
-        * @var null|array $actors Actor names that Audit Log Events will be filtered by.
-        * @var null|array $targets Target types that Audit Log Events will be filtered by.
-        *
-        * @return Resource\AuditLogExport
+     * @var null|string $organizationId Description of the record.
+     * @var null|string $rangeStart ISO-8601 Timestamp of the start of Export's the date range.
+     * @var null|string $rangeEnd ISO-8601 Timestamp  of the end of Export's the date range.
+     * @var null|array $actions Actions that Audit Log Events will be filtered by.
+     * @var null|array $actors Actor names that Audit Log Events will be filtered by.
+     * @var null|array $targets Target types that Audit Log Events will be filtered by.
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return Resource\AuditLogExport
      */
 
     public function createExport($organizationId, $rangeStart, $rangeEnd, $actions = null, $actors = null, $targets = null)
@@ -95,11 +99,12 @@ class AuditLogs
     }
 
     /**
-       * @param string $auditLogExportId Unique identifier of the Audit Log Export
-       *
-       * @return Resource\AuditLogExport
-    */
-
+     * @param string $auditLogExportId Unique identifier of the Audit Log Export
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return Resource\AuditLogExport
+     */
     public function getExport($auditLogExportId)
     {
         $getExportPath = "audit_logs/exports/{$auditLogExportId}";

--- a/lib/AuditTrail.php
+++ b/lib/AuditTrail.php
@@ -35,6 +35,8 @@ class AuditTrail
      * @param array $event Associative array containing the keys detailed above
      * @param string $idempotencyKey Unique key guaranteeing idempotency of events for 24 hours
      *
+     * @throws Exception\WorkOSException
+     *
      * @return boolean true if an event was successfully created
      */
     public function createEvent($event, $idempotencyKey = null)
@@ -78,6 +80,8 @@ class AuditTrail
      * @param string $before Event ID to look before
      * @param string $after Event ID to look after
      * @param \WorkOS\Resource\Order $order The Order in which to paginate records
+     *
+     * @throws Exception\WorkOSException
      *
      * @return array An array containing the following:
      *      null|string Event ID to use as before cursor

--- a/lib/DirectorySync.php
+++ b/lib/DirectorySync.php
@@ -22,6 +22,8 @@ class DirectorySync
      * @param null|string $organizationId Unique ID for an organization
      * @param \WorkOS\Resource\Order $order The Order in which to paginate records
      *
+     * @throws Exception\WorkOSException
+     *
      * @return array An array containing the following:
      *      null|string Directory ID to use as before cursor
      *      null|string Directory ID to use as after cursor
@@ -74,6 +76,8 @@ class DirectorySync
      * @param null|string $after Directory Group ID to look after
      * @param \WorkOS\Resource\Order $order The Order in which to paginate records
      *
+     * @throws Exception\WorkOSException
+     *
      * @return array An array containing the following:
      *      null|string Directory Group ID to use as before cursor
      *      null|string Directory Group ID to use as after cursor
@@ -124,6 +128,8 @@ class DirectorySync
      *
      * @param string $directoryGroup Directory Group ID
      *
+     * @throws Exception\WorkOSException
+     *
      * @return \WorkOS\Resource\DirectoryGroup
      */
     public function getGroup($directoryGroup)
@@ -150,6 +156,8 @@ class DirectorySync
      * @param null|string $before Directory User ID to look before
      * @param null|string $after Directory User ID to look after
      * @param \WorkOS\Resource\Order $order The Order in which to paginate records
+     *
+     * @throws Exception\WorkOSException
      *
      * @return array An array containing the following:
      *      null|string Directory User ID to use as before cursor
@@ -201,6 +209,8 @@ class DirectorySync
      *
      * @param string $directoryUser Directory User ID
      *
+     * @throws Exception\WorkOSException
+     *
      * @return \WorkOS\Resource\DirectoryUser
      */
     public function getUser($directoryUser)
@@ -222,6 +232,8 @@ class DirectorySync
      * Delete a Directory.
      *
      * @param string $directory Directory ID
+     *
+     * @throws Exception\WorkOSException
      *
      * @return \WorkOS\Resource\Response
      */
@@ -245,9 +257,10 @@ class DirectorySync
      *
      * @param string $directory WorkOS directory ID
      *
+     * @throws Exception\WorkOSException
+     *
      * @return \WorkOS\Resource\Directory
      */
-
     public function getDirectory($directory)
     {
         $directoriesPath = "directories/{$directory}";

--- a/lib/Exception/AuthenticationException.php
+++ b/lib/Exception/AuthenticationException.php
@@ -5,6 +5,6 @@ namespace WorkOS\Exception;
 /**
  * Class AuthenticationException.
  */
-class AuthenticationException extends BaseRequestException
+class AuthenticationException extends BaseRequestException implements WorkOSException
 {
 }

--- a/lib/Exception/AuthorizationException.php
+++ b/lib/Exception/AuthorizationException.php
@@ -5,6 +5,6 @@ namespace WorkOS\Exception;
 /**
  * Class AuthorizationException.
  */
-class AuthorizationException extends BaseRequestException
+class AuthorizationException extends BaseRequestException implements WorkOSException
 {
 }

--- a/lib/Exception/BadRequestException.php
+++ b/lib/Exception/BadRequestException.php
@@ -5,6 +5,6 @@ namespace WorkOS\Exception;
 /**
  * Class BadRequestException.
  */
-class BadRequestException extends BaseRequestException
+class BadRequestException extends BaseRequestException implements WorkOSException
 {
 }

--- a/lib/Exception/BaseRequestException.php
+++ b/lib/Exception/BaseRequestException.php
@@ -7,7 +7,7 @@ namespace WorkOS\Exception;
  *
  * Base Exception for use in filtering a response for information.
  */
-class BaseRequestException extends \Exception
+class BaseRequestException extends \Exception implements WorkOSException
 {
     public $requestId = "";
     public $responseError;

--- a/lib/Exception/ConfigurationException.php
+++ b/lib/Exception/ConfigurationException.php
@@ -7,6 +7,6 @@ namespace WorkOS\Exception;
  *
  * Thrown when a WorkOS package configuration related issue is encountered.
  */
-class ConfigurationException extends \Exception
+class ConfigurationException extends \Exception implements WorkOSException
 {
 }

--- a/lib/Exception/GenericException.php
+++ b/lib/Exception/GenericException.php
@@ -7,7 +7,7 @@ namespace WorkOS\Exception;
  *
  * Generic WorkOS Exception.
  */
-class GenericException extends \Exception
+class GenericException extends \Exception implements WorkOSException
 {
     public $data;
 

--- a/lib/Exception/NotFoundException.php
+++ b/lib/Exception/NotFoundException.php
@@ -5,6 +5,6 @@ namespace WorkOS\Exception;
 /**
  * Class NotFoundException.
  */
-class NotFoundException extends BaseRequestException
+class NotFoundException extends BaseRequestException implements WorkOSException
 {
 }

--- a/lib/Exception/ServerException.php
+++ b/lib/Exception/ServerException.php
@@ -5,6 +5,6 @@ namespace WorkOS\Exception;
 /**
  * Class ServerException.
  */
-class ServerException extends BaseRequestException
+class ServerException extends BaseRequestException implements WorkOSException
 {
 }

--- a/lib/Exception/UnexpectedValueException.php
+++ b/lib/Exception/UnexpectedValueException.php
@@ -5,6 +5,6 @@ namespace WorkOS\Exception;
 /**
  * class UnexpectedValueException.
  */
-class UnexpectedValueException extends \Exception
+class UnexpectedValueException extends \Exception implements WorkOSException
 {
 }

--- a/lib/Exception/WorkOSException.php
+++ b/lib/Exception/WorkOSException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace WorkOS\Exception;
+
+use Throwable;
+
+interface WorkOSException extends Throwable
+{
+}

--- a/lib/MFA.php
+++ b/lib/MFA.php
@@ -16,8 +16,9 @@ class MFA
      * @param null|string $totpIssuer - Name of the Organization
      * @param null|string $totpUser - Email of user
      * @param null|string $phoneNumber - Phone number of user
-    */
-
+     *
+     * @throws Exception\WorkOSException
+     */
     public function enrollFactor(
         $type,
         $totpIssuer = null,
@@ -73,8 +74,7 @@ class MFA
      *
      * @param string $authenticationFactorId - ID of the authentication factor
      * @param string|null $smsTemplate - Optional parameter to customize the message for sms type factors. Must include "{{code}}" if used.
-    */
-
+     */
     public function challengeFactor(
         $authenticationFactorId,
         $smsTemplate = null
@@ -140,8 +140,9 @@ class MFA
      *
      * @param string $authenticationChallengeId - The ID of the authentication challenge that provided the user the verification code.
      * @param string $code - The verification code sent to and provided by the end user.
-    */
-
+     *
+     * @throws Exception\WorkOSException
+     */
     public function verifyChallenge(
         $authenticationChallengeId,
         $code
@@ -173,8 +174,9 @@ class MFA
      * Returns a Factor.
      *
      * @param string $authenticationFactorId - WorkOS Factor ID
-    */
-
+     *
+     * @throws Exception\WorkOSException
+     */
     public function getFactor($authenticationFactorId)
     {
         $getFactorPath = "auth/factors/{$authenticationFactorId}";
@@ -195,8 +197,9 @@ class MFA
      * Deletes a Factor.
      *
      * @param string $authenticationFactorId - WorkOS Factor ID
-    */
-
+     *
+     * @throws Exception\WorkOSException
+     */
     public function deleteFactor($authenticationFactorId)
     {
         $deleteFactorPath = "auth/factors/{$authenticationFactorId}";

--- a/lib/Organizations.php
+++ b/lib/Organizations.php
@@ -21,6 +21,8 @@ class Organizations
      * @param null|string $after Organization ID to look after
      * @param \WorkOS\Resource\Order $order The Order in which to paginate records
      *
+     * @throws Exception\WorkOSException
+     *
      * @return array An array containing the following:
      *      null|string Organization ID to use as before cursor
      *      null|string Organization ID to use as after cursor
@@ -68,6 +70,8 @@ class Organizations
      *      that are outside of the Organization's configured User Email Domains.
      * @param null|string $idempotencyKey is a unique string that identifies a distinct organization
      *
+     * @throws Exception\WorkOSException
+     *
      * @return \WorkOS\Resource\Organization
      */
     public function createOrganization($name, $domains, $allowProfilesOutsideOrganization = null, $idempotencyKey = null)
@@ -93,8 +97,9 @@ class Organizations
      * @param string $name The name of the Organization.
      * @param null|boolean $allowProfilesOutsideOrganization Whether Connections within the Organization allow profiles
      *      that are outside of the Organization's configured User Email Domains.
+     *
+     * @throws Exception\WorkOSException
      */
-
     public function updateOrganization($organization, $domains, $name, $allowProfilesOutsideOrganization = null)
     {
         $organizationsPath = "organizations/{$organization}";
@@ -115,9 +120,10 @@ class Organizations
      *
      * @param string $organization WorkOS organization ID
      *
+     * @throws Exception\WorkOSException
+     *
      * @return \WorkOS\Resource\Organization
      */
-
     public function getOrganization($organization)
     {
         $organizationsPath = "organizations/{$organization}";
@@ -131,6 +137,8 @@ class Organizations
      * Delete an Organization.
      *
      * @param string $organization WorkOS organization ID
+     *
+     * @throws Exception\WorkOSException
      *
      * @return \WorkOS\Resource\Response
      */

--- a/lib/Passwordless.php
+++ b/lib/Passwordless.php
@@ -18,6 +18,9 @@ class Passwordless
      * @param string $type The only supported ConnectionType at the time of this writing is MagicLink
      * @param $connection the unique WorkOS connection_ID
      * @param $expiresIn The number of seconds the Passwordless Session should live before expiring.
+     *
+     * @throws Exception\WorkOSException
+     *
      * @return  \WorkOS\Resource\PasswordlessSession
      */
     public function createSession($email, $redirectUri, $state, $type, $connection, $expiresIn)
@@ -50,10 +53,12 @@ class Passwordless
         return Resource\PasswordlessSession::constructFromResponse($response);
     }
 
-
-    /** Send a passwordless link via email from WorkOS.
+    /**
+     * Send a passwordless link via email from WorkOS.
      *
      * @param \WorkOS\Resource\PasswordlessSession $session Passwordless session generated through Passwordless->createSession
+     *
+     * @throws Exception\WorkOSException
      *
      * @return boolean true
      */

--- a/lib/Portal.php
+++ b/lib/Portal.php
@@ -19,6 +19,8 @@ class Portal
      * @param null|string $successUrl The URL to which WorkOS will redirect users to
      *      upon successfully setting up Single Sign On or Directory Sync. (Optional).
      *
+     * @throws Exception\WorkOSException
+     *
      * @return \WorkOS\Resource\PortalLink
      */
     public function generateLink($organization, $intent, $returnUrl = null, $successUrl = null)

--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -2,9 +2,10 @@
 
 namespace WorkOS;
 
+use WorkOS\Exception;
+
 /**
  * Class SSO.
- *
  * This class facilitates the use of WorkOS SSO.
  */
 class SSO
@@ -20,6 +21,9 @@ class SSO
      * @param null|string $organization Unique identifier for a WorkOS Organization
      * @param null|string $domainHint DDomain hint that will be passed as a parameter to the IdP login page
      * @param null|string $loginHint Username/email hint that will be passed as a parameter to the to IdP login page
+     *
+     * @throws Exception\UnexpectedValueException
+     * @throws Exception\ConfigurationException
      *
      * @return string
      */
@@ -92,6 +96,8 @@ class SSO
      *
      * @param string $code Code returned by WorkOS on completion of OAuth 2.0 flow
      *
+     * @throws Exception\WorkOSException
+     *
      * @return \WorkOS\Resource\ProfileAndToken
      */
     public function getProfileAndToken($code)
@@ -114,6 +120,9 @@ class SSO
      * Verify that SSO has been completed successfully and retrieve the identity of the user.
      *
      * @param string $accessToken, the token used to authenticate the API call
+     *
+     * @throws Exception\GenericException
+     *
      * @return \WorkOS\Resource\Profile
      */
     public function getProfile($accessToken)
@@ -147,6 +156,8 @@ class SSO
      *
      * @param string $connection Connection ID
      *
+     * @throws Exception\WorkOSException
+     *
      * @return \WorkOS\Resource\Response
      */
     public function deleteConnection($connection)
@@ -168,6 +179,8 @@ class SSO
      * Get a Connection.
      *
      * @param string $connection Connection ID
+     *
+     * @throws Exception\WorkOSException
      *
      * @return \WorkOS\Resource\Connection
      */
@@ -198,6 +211,8 @@ class SSO
      * @param null|string $before Connection ID to look before
      * @param null|string $after Connection ID to look after
      * @param \WorkOS\Resource\Order $order The Order in which to paginate records
+     *
+     * @throws Exception\WorkOSException
      *
      * @return array An array containing the following:
      *      null|string Connection ID to use as before cursor

--- a/lib/WorkOS.php
+++ b/lib/WorkOS.php
@@ -61,6 +61,8 @@ class WorkOS
     }
 
     /**
+     * @throws \WorkOS\Exception\ConfigurationException
+     *
      * @return null|string WorkOS Client ID
      */
     public static function getClientId()


### PR DESCRIPTION
Hi @sheldonvaughn,

The PHPdoc is missing a lot of `@throws` tag, most of the time it's because `::request` method is called and this can throw a lot of different WorkOS exceptions. I recently got the issue of not catching one of these exceptions, and this would have been caught thanks to phpdoc and PHPStorm/PHPStan.

Also, since the `::request` method can throw a lot of different exceptions:
```
@throws \WorkOS\Exception\GenericException if a client level exception is encountered
@throws \WorkOS\Exception\ServerException if a 5xx status code is returned
@throws \WorkOS\Exception\AuthenticationException if a 401 status code is returned
@throws \WorkOS\Exception\AuthorizationException if a 403 status code is returned
@throws \WorkOS\Exception\NotFoundException if a 404 status code is returned
@throws \WorkOS\Exception\BadRequestException if a 400 status code is returned
```
I introduced an interface `WorkOSException` in order to
- Not copy paster those 6 lines everywhere
- Allow catching all these exception in once with `catch (WorkOSException)`.