### PR TITLE
Fix team name in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 # See GitHub's docs for more details:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-# PHPers Team
-* @workos-inc/php
+* @workos/php


### PR DESCRIPTION
## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
