### PR TITLE
Add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+.* export-ignore
+scripts export-ignore
+tests export-ignore
+phpunit.xml export-ignore


### PR DESCRIPTION
Hi @sheldonvaughn,

I noticed when installing the latest version that some useless files/folders were downloaded, like the test folder.
The gitattributes file allow to avoid this.

I listed all the files that I think is not needed:
- The dot folder/files
- the script and tests folder
- the phpunit config