### PR TITLE
Add `actorNames` and `actorIds` to `createExport`

### DIFF
--- a/lib/AuditLogs.php
+++ b/lib/AuditLogs.php
@@ -66,13 +66,15 @@ class AuditLogs
      * @var null|array $actions Actions that Audit Log Events will be filtered by.
      * @var null|array $actors Actor names that Audit Log Events will be filtered by.
      * @var null|array $targets Target types that Audit Log Events will be filtered by.
+     * @var null|array $actorNames Actor names that Audit Log Events will be filtered by.
+     * @var null|array $actorIds Actor IDs that Audit Log Events will be filtered by.
      *
      * @throws Exception\WorkOSException
      *
      * @return Resource\AuditLogExport
      */
 
-    public function createExport($organizationId, $rangeStart, $rangeEnd, $actions = null, $actors = null, $targets = null)
+    public function createExport($organizationId, $rangeStart, $rangeEnd, $actions = null, $actors = null, $targets = null, $actorNames = null, $actorIds = null)
     {
         $createExportPath = "audit_logs/exports";
 
@@ -87,7 +89,19 @@ class AuditLogs
         };
 
         if (!is_null($actors)) {
+            $msg = "'actors' is deprecated. Please use 'actorNames' instead'";
+
+            error_log($msg);
+
             $params["actors"] = $actors;
+        };
+
+        if (!is_null($actorNames)) {
+            $params["actor_names"] = $actorNames;
+        };
+
+        if (!is_null($actorIds)) {
+            $params["actor_ids"] = $actorIds;
         };
 
         if (!is_null($targets)) {

--- a/tests/WorkOS/AuditLogsTest.php
+++ b/tests/WorkOS/AuditLogsTest.php
@@ -78,13 +78,17 @@ class AuditLogsTest extends \PHPUnit\Framework\TestCase
             "name" => "team",
         ];
         $actions = ["document.updated"];
-        $actors = ["user_123"];
+        $actors = ["Smith"];
+        $actorNames = ["Smith"];
+        $actorIds = ["user_123"];
         $params = [
             "organization_id" => $organizationId,
             "range_end" => $rangeEnd,
             "range_start" => $rangeStart,
             "actions" => $actions,
             "actors" => $actors,
+            "actor_names" => $actorNames,
+            "actor_ids" => $actorIds,
             "targets" => $targets
         ];
 
@@ -99,7 +103,7 @@ class AuditLogsTest extends \PHPUnit\Framework\TestCase
             $result
         );
 
-        $auditLogExport = $this->al->createExport($organizationId, $rangeStart, $rangeEnd, $actions, $actors, $targets);
+        $auditLogExport = $this->al->createExport($organizationId, $rangeStart, $rangeEnd, $actions, $actors, $targets, $actorNames, $actorIds);
         $exportFixture = $this->createExportFixture();
 
         $this->assertSame($exportFixture, $auditLogExport->toArray());


### PR DESCRIPTION
## Description

- Adds `actorNames` and `actorIds` to `createExport`
- Deprecates `actors` in favor of `actorNames`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
