### PR TITLE
Remove illuminate/support dependency to allow Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
   ],
   "require": {
     "php": ">=7.3.0",
-    "ext-curl": "*",
-    "illuminate/support" : "^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+    "ext-curl": "*"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.15|^3.6",


### PR DESCRIPTION
## Description
In the past we've had to add new Laravel versions to composer.json e.g. "illuminate/support" : "^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0", however this dependency is unused in the PHP SDK.
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
