### PR TITLE
Fix syntax in Client Test breaking CI

### DIFF
--- a/tests/WorkOS/ClientTest.php
+++ b/tests/WorkOS/ClientTest.php
@@ -120,8 +120,8 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-    * @dataProvider requestExceptionTestProvider
-    */
+     * @dataProvider requestExceptionTestProvider
+     */
     public function testClientThrowsRequestExceptionsWithErrorAndErrorDescription($statusCode, $exceptionClass)
     {
         $this->withApiKeyAndClientId();

--- a/tests/WorkOS/ClientTest.php
+++ b/tests/WorkOS/ClientTest.php
@@ -89,7 +89,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-      /**
+    /**
      * @dataProvider requestExceptionTestProvider
      */
     public function testClientThrowsRequestExceptionsWithMessageAndCode($statusCode, $exceptionClass)
@@ -119,9 +119,9 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-     /**
-     * @dataProvider requestExceptionTestProvider
-     */
+    /**
+    * @dataProvider requestExceptionTestProvider
+    */
     public function testClientThrowsRequestExceptionsWithErrorAndErrorDescription($statusCode, $exceptionClass)
     {
         $this->withApiKeyAndClientId();
@@ -149,7 +149,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-       /**
+    /**
      * @dataProvider requestExceptionTestProvider
      */
     public function testClientThrowsRequestExceptionsWithErrors($statusCode, $exceptionClass)


### PR DESCRIPTION
## Description
PR to unblock https://github.com/workos/workos-php/pull/149#pullrequestreview-1514851429
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
