### PR TITLE
Add `sendMagicAuthCode` function

### DIFF
--- a/lib/Resource/MagicAuthChallenge.php
+++ b/lib/Resource/MagicAuthChallenge.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class MagicAuthChallenge.
+ */
+class MagicAuthChallenge extends BaseWorkOSResource
+{
+    public const RESOURCE_TYPE = "magic_auth_challenge";
+
+    public const RESOURCE_ATTRIBUTES = [
+        "object",
+        "id"
+    ];
+
+    public const RESPONSE_TO_RESOURCE_KEY = [
+        "object" => "object",
+        "id" => "id"
+    ];
+}

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -165,4 +165,32 @@ class UserManagement
 
         return Resource\User::constructFromResponse($response);
     }
+
+    /**
+     * Creates a one-time Magic Auth code and emails it to the user.
+     *
+     * @param string $emailAddress The email address the one-time code will be sent to.
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\MagicAuthChallenge
+     */
+    public function sendMagicAuthCode($emailAddress)
+    {
+        $sendCodePath = "users/magic_auth/send";
+
+        $params = [
+            "email_address" => $emailAddress,
+        ];
+
+        $response = Client::request(
+            Client::METHOD_POST,
+            $sendCodePath,
+            null,
+            $params,
+            true
+        );
+
+        return Resource\MagicAuthChallenge::constructFromResponse($response);
+    }
 }

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -147,6 +147,30 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($user, $response->toArray());
     }
 
+    private function testSendMagicAuthCode()
+    {
+        $sendCodePath = "users/magic_auth/send";
+
+        $result = $this->sendMagicAuthCodeResponseFixture();
+
+        $params = [
+            "email" => "test@test.com"
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $sendCodePath,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $magicAuthChallenge = $this->magicAuthChallengeFixture();
+
+        $response = $this->userManagement->sendMagicAuthCode("test@test.com");
+        $this->assertSame($magicAuthChallenge, $response->toArray());
+    }
     // Fixtures
 
     private function addUserToOrganizationResponseFixture()
@@ -180,6 +204,14 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "google_oauth_profile_id" => "goog_123ABC",
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z"
+        ]);
+    }
+
+    private function sendMagicAuthCodeResponseFixture()
+    {
+        return json_encode([
+            "object" => "magic_auth_challenge",
+            "id" => "auth_challenge_01E4ZCR3C56J083X43JQXF3JK5"
         ]);
     }
 
@@ -240,6 +272,14 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z"
         ]);
+    }
+
+    private function magicAuthChallengeFixture()
+    {
+        return [
+            "object" => "magic_auth_challenge",
+            "id" => "auth_challenge_01E4ZCR3C56J083X43JQXF3JK5"
+        ];
     }
 
     private function userFixture()


### PR DESCRIPTION
## Description
Adds the [Send Code](https://workos.com/docs/reference/user-management/magic-auth/send-code) function
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
