### PR TITLE
Add `createEmailVerificationChallenge` and `completeEmailVerification` functions

### DIFF
--- a/lib/Resource/UserAndToken.php
+++ b/lib/Resource/UserAndToken.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class UserAndToken.
+ *
+ * @property string  $token
+ * @property User $user
+ */
+class UserAndToken extends BaseWorkOSResource
+{
+    public const RESOURCE_ATTRIBUTES = [
+        "token",
+        "user"
+    ];
+
+    public const RESPONSE_TO_RESOURCE_KEY = [
+        "token" => "token"
+    ];
+
+    public static function constructFromResponse($response)
+    {
+        $instance = parent::constructFromResponse($response);
+
+        $instance->values["user"] = User::constructFromResponse($response["user"]);
+
+        return $instance;
+    }
+}

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -211,32 +211,4 @@ class UserManagement
 
         return Resource\User::constructFromResponse($response);
     }
-
-    /**
-     * Creates a one-time Magic Auth code and emails it to the user.
-     *
-     * @param string $emailAddress The email address the one-time code will be sent to.
-     *
-     * @throws Exception\WorkOSException
-     *
-     * @return \WorkOS\Resource\MagicAuthChallenge
-     */
-    public function sendMagicAuthCode($emailAddress)
-    {
-        $sendCodePath = "users/magic_auth/send";
-
-        $params = [
-            "email_address" => $emailAddress,
-        ];
-
-        $response = Client::request(
-            Client::METHOD_POST,
-            $sendCodePath,
-            null,
-            $params,
-            true
-        );
-
-        return Resource\MagicAuthChallenge::constructFromResponse($response);
-    }
 }

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -101,7 +101,7 @@ class UserManagement
 
         $response = Client::request(Client::METHOD_POST, $createEmailVerificationPath, null, $params, true);
 
-        return Resource\UserAndtoken::constructFromResponse($response);
+        return Resource\UserAndToken::constructFromResponse($response);
     }
 
     /**

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -82,6 +82,52 @@ class UserManagement
     }
 
     /**
+     * Create Email Verification Challenge.
+     *
+     * @param string $id The unique ID of the User whose email address will be verified.
+     * @param string $verificationUrl The URL that will be linked to in the verification email.
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\UserAndToken
+     */
+    public function createEmailVerificationChallenge($id, $verificationUrl)
+    {
+        $createEmailVerificationPath = "users/{$id}/email_verification_challenge";
+
+        $params = [
+            "verification_url" => $verificationUrl
+        ];
+
+        $response = Client::request(Client::METHOD_POST, $createEmailVerificationPath, null, $params, true);
+
+        return Resource\UserAndtoken::constructFromResponse($response);
+    }
+
+    /**
+     * Complete Email Verification.
+     *
+     * @param string $token The verification token emailed to the user.
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\User
+     */
+    public function completeEmailVerification($token)
+    {
+        $completeEmailVerificationPath = "users/email_verification";
+
+        $params = [
+            "token" => $token
+        ];
+
+        $response = Client::request(Client::METHOD_POST, $completeEmailVerificationPath, null, $params, true);
+
+        return Resource\User::constructFromResponse($response);
+    }
+
+
+    /**
      * List Users.
      *
      * @param null|string $type User type "unmanaged" or "managed"
@@ -164,5 +210,33 @@ class UserManagement
         $response = Client::request(Client::METHOD_POST, $usersPath, $headers, $params, true);
 
         return Resource\User::constructFromResponse($response);
+    }
+
+    /**
+     * Creates a one-time Magic Auth code and emails it to the user.
+     *
+     * @param string $emailAddress The email address the one-time code will be sent to.
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\MagicAuthChallenge
+     */
+    public function sendMagicAuthCode($emailAddress)
+    {
+        $sendCodePath = "users/magic_auth/send";
+
+        $params = [
+            "email_address" => $emailAddress,
+        ];
+
+        $response = Client::request(
+            Client::METHOD_POST,
+            $sendCodePath,
+            null,
+            $params,
+            true
+        );
+
+        return Resource\MagicAuthChallenge::constructFromResponse($response);
     }
 }

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -71,6 +71,59 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($user, $response->toArray());
     }
 
+    public function testCreateEmailVerificationChallenge()
+    {
+        $id = "user_01E4ZCR3C56J083X43JQXF3JK5";
+        $createEmailVerificationPath = "users/{$id}/email_verification_challenge";
+
+        $result = $this->createUserAndTokenResponseFixture();
+
+        $params = [
+            "verification_url" => "https://your-app.com/verify-email",
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $createEmailVerificationPath,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+
+        $userFixture = $this->userFixture();
+
+        $response = $this->userManagement->createEmailVerificationChallenge("user_01E4ZCR3C56J083X43JQXF3JK5", "https://your-app.com/verify-email");
+        $this->assertSame("01DMEK0J53CVMC32CK5SE0KZ8Q", $response->token);
+        $this->assertSame($userFixture, $response->user->toArray());
+    }
+
+    public function testCompleteEmailVerification()
+    {
+        $usersPath = "users/email_verification";
+
+        $result = $this->createUserResponseFixture();
+
+        $params = [
+            "token" => "01DMEK0J53CVMC32CK5SE0KZ8Q",
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $usersPath,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $user = $this->userFixture();
+
+        $response = $this->userManagement->completeEmailVerification("01DMEK0J53CVMC32CK5SE0KZ8Q");
+        $this->assertSame($user, $response->toArray());
+    }
+
 
     public function testGetUser()
     {
@@ -147,7 +200,51 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($user, $response->toArray());
     }
 
+    private function testSendMagicAuthCode()
+    {
+        $sendCodePath = "users/magic_auth/send";
+
+        $result = $this->sendMagicAuthCodeResponseFixture();
+
+        $params = [
+            "email" => "test@test.com"
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $sendCodePath,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $magicAuthChallenge = $this->magicAuthChallengeFixture();
+
+        $response = $this->userManagement->sendMagicAuthCode("test@test.com");
+        $this->assertSame($magicAuthChallenge, $response->toArray());
+    }
     // Fixtures
+
+    private function createUserAndTokenResponseFixture()
+    {
+        return json_encode([
+            "token" => "01DMEK0J53CVMC32CK5SE0KZ8Q",
+            "user" => [
+                "object" => "user",
+                "id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
+                "user_type" => "unmanaged",
+                "email" => "test@test.com",
+                "first_name" => "Damien",
+                "last_name" => "Alabaster",
+                "email_verified_at" => "2021-07-25T19:07:33.155Z",
+                "sso_profile_id" => "1AO5ZPQDE43",
+                "google_oauth_profile_id" => "goog_123ABC",
+                "created_at" => "2021-06-25T19:07:33.155Z",
+                "updated_at" => "2021-06-25T19:07:33.155Z"
+            ]
+        ]);
+    }
 
     private function addUserToOrganizationResponseFixture()
     {
@@ -180,6 +277,14 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "google_oauth_profile_id" => "goog_123ABC",
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z"
+        ]);
+    }
+
+    private function sendMagicAuthCodeResponseFixture()
+    {
+        return json_encode([
+            "object" => "magic_auth_challenge",
+            "id" => "auth_challenge_01E4ZCR3C56J083X43JQXF3JK5"
         ]);
     }
 
@@ -240,6 +345,14 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z"
         ]);
+    }
+
+    private function magicAuthChallengeFixture()
+    {
+        return [
+            "object" => "magic_auth_challenge",
+            "id" => "auth_challenge_01E4ZCR3C56J083X43JQXF3JK5"
+        ];
     }
 
     private function userFixture()

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -200,30 +200,6 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($user, $response->toArray());
     }
 
-    private function testSendMagicAuthCode()
-    {
-        $sendCodePath = "users/magic_auth/send";
-
-        $result = $this->sendMagicAuthCodeResponseFixture();
-
-        $params = [
-            "email" => "test@test.com"
-        ];
-
-        $this->mockRequest(
-            Client::METHOD_POST,
-            $sendCodePath,
-            null,
-            $params,
-            true,
-            $result
-        );
-
-        $magicAuthChallenge = $this->magicAuthChallengeFixture();
-
-        $response = $this->userManagement->sendMagicAuthCode("test@test.com");
-        $this->assertSame($magicAuthChallenge, $response->toArray());
-    }
     // Fixtures
 
     private function createUserAndTokenResponseFixture()
@@ -277,14 +253,6 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "google_oauth_profile_id" => "goog_123ABC",
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z"
-        ]);
-    }
-
-    private function sendMagicAuthCodeResponseFixture()
-    {
-        return json_encode([
-            "object" => "magic_auth_challenge",
-            "id" => "auth_challenge_01E4ZCR3C56J083X43JQXF3JK5"
         ]);
     }
 
@@ -345,14 +313,6 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z"
         ]);
-    }
-
-    private function magicAuthChallengeFixture()
-    {
-        return [
-            "object" => "magic_auth_challenge",
-            "id" => "auth_challenge_01E4ZCR3C56J083X43JQXF3JK5"
-        ];
     }
 
     private function userFixture()


### PR DESCRIPTION
## Description
Adds the User Management Email Verification suite of functions:
https://workos.com/docs/reference/user-management/email-verification

Create an Email Verification Challenge
https://workos.com/docs/reference/user-management/email-verification/challenge

Complete Email Verification
https://workos.com/docs/reference/user-management/email-verification/verify

Resolves USRLD-745
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
