### PR TITLE
Implement `MagicAuthToken` for Email Verification functions

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -85,43 +85,41 @@ class UserManagement
      * Create Email Verification Challenge.
      *
      * @param string $id The unique ID of the User whose email address will be verified.
-     * @param string $verificationUrl The URL that will be linked to in the verification email.
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\UserAndToken
+     * @return \WorkOS\Resource\MagicAuthToken
      */
-    public function createEmailVerificationChallenge($id, $verificationUrl)
+    public function sendVerificationEmail($id)
     {
-        $createEmailVerificationPath = "users/{$id}/email_verification_challenge";
+        $sendVerificationEmailPath = "users/{$id}/send_verification_email";
 
-        $params = [
-            "verification_url" => $verificationUrl
-        ];
+        $response = Client::request(Client::METHOD_POST, $sendVerificationEmailPath, null, null, true);
 
-        $response = Client::request(Client::METHOD_POST, $createEmailVerificationPath, null, $params, true);
-
-        return Resource\UserAndToken::constructFromResponse($response);
+        return Resource\MagicAuthChallenge::constructFromResponse($response);
     }
 
     /**
      * Complete Email Verification.
      *
-     * @param string $token The verification token emailed to the user.
+     * @param string $magicAuthChallengeId The challenge ID returned from the send verification email endpoint.
+     * @param string $code The one-time code emailed to the user.
+     * 
      *
      * @throws Exception\WorkOSException
      *
      * @return \WorkOS\Resource\User
      */
-    public function completeEmailVerification($token)
+    public function verifyEmail($magicAuthChallengeId, $code)
     {
-        $completeEmailVerificationPath = "users/email_verification";
+        $verifyEmailPath = "users/verify_email";
 
         $params = [
-            "token" => $token
+            "magic_auth_challenge_id" => $magicAuthChallengeId,
+            "code" => $code
         ];
 
-        $response = Client::request(Client::METHOD_POST, $completeEmailVerificationPath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $verifyEmailPath, null, $params, true);
 
         return Resource\User::constructFromResponse($response);
     }

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -88,7 +88,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\MagicAuthToken
+     * @return \WorkOS\Resource\MagicAuthchallenge
      */
     public function sendVerificationEmail($id)
     {

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -104,7 +104,7 @@ class UserManagement
      *
      * @param string $magicAuthChallengeId The challenge ID returned from the send verification email endpoint.
      * @param string $code The one-time code emailed to the user.
-     * 
+     *
      *
      * @throws Exception\WorkOSException
      *

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -71,42 +71,39 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($user, $response->toArray());
     }
 
-    public function testCreateEmailVerificationChallenge()
+    public function testSendVerificationEmail()
     {
         $id = "user_01E4ZCR3C56J083X43JQXF3JK5";
-        $createEmailVerificationPath = "users/{$id}/email_verification_challenge";
+        $sendVerificationEmailPath = "users/{$id}/send_verification_email";
 
-        $result = $this->createUserAndTokenResponseFixture();
+        $result = $this->sendMagicAuthCodeResponseFixture();
 
-        $params = [
-            "verification_url" => "https://your-app.com/verify-email",
-        ];
 
         $this->mockRequest(
             Client::METHOD_POST,
-            $createEmailVerificationPath,
+            $sendVerificationEmailPath,
             null,
-            $params,
+            null,
             true,
             $result
         );
 
 
-        $userFixture = $this->userFixture();
+        $magicAuthChallenge = $this->magicAuthChallengeFixture();
 
-        $response = $this->userManagement->createEmailVerificationChallenge("user_01E4ZCR3C56J083X43JQXF3JK5", "https://your-app.com/verify-email");
-        $this->assertSame("01DMEK0J53CVMC32CK5SE0KZ8Q", $response->token);
-        $this->assertSame($userFixture, $response->user->toArray());
+        $response = $this->userManagement->sendVerificationEmail("user_01E4ZCR3C56J083X43JQXF3JK5");
+        $this->assertSame($magicAuthChallenge, $response->toArray());
     }
 
-    public function testCompleteEmailVerification()
+    public function testVerifyEmail()
     {
-        $usersPath = "users/email_verification";
+        $usersPath = "users/verify_email";
 
         $result = $this->createUserResponseFixture();
 
         $params = [
-            "token" => "01DMEK0J53CVMC32CK5SE0KZ8Q",
+            "magic_auth_challenge_id" => "auth_challenge_01E4ZCR3C56J083X43JQXF3JK5",
+            "code" => "01DMEK0J53CVMC32CK5SE0KZ8Q",
         ];
 
         $this->mockRequest(
@@ -120,7 +117,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $user = $this->userFixture();
 
-        $response = $this->userManagement->completeEmailVerification("01DMEK0J53CVMC32CK5SE0KZ8Q");
+        $response = $this->userManagement->verifyEmail("auth_challenge_01E4ZCR3C56J083X43JQXF3JK5", "01DMEK0J53CVMC32CK5SE0KZ8Q");
         $this->assertSame($user, $response->toArray());
     }
 


### PR DESCRIPTION
## Description
Updates the User Management Email Verification suite of functions to use the MagicAuthToken for validation.
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
