### PR TITLE
Add `authenticateUserWith*`  functions

### DIFF
--- a/lib/Resource/Session.php
+++ b/lib/Resource/Session.php
@@ -3,7 +3,7 @@
 namespace WorkOS\Resource;
 
 /**
- * Class Profile.
+ * Class Session.
  *
  * @property string $id
  * @property string $created_at

--- a/lib/Resource/Session.php
+++ b/lib/Resource/Session.php
@@ -14,7 +14,7 @@ namespace WorkOS\Resource;
  */
 class Session extends BaseWorkOSResource
 {
-    public const RESOURCE_TYPE = "profile";
+    public const RESOURCE_TYPE = "session";
 
     public const RESOURCE_ATTRIBUTES = [
         "object",

--- a/lib/Resource/Session.php
+++ b/lib/Resource/Session.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class Profile.
+ *
+ * @property string $id
+ * @property string $created_at
+ * @property string $expires_at
+ * @property string $token
+ * @property string $authorized_organizations
+ * @property string $unauthorized_organizations
+ */
+class Session extends BaseWorkOSResource
+{
+    public const RESOURCE_TYPE = "profile";
+
+    public const RESOURCE_ATTRIBUTES = [
+        "object",
+        "id",
+        "token",
+        "authorizedOrganizations",
+        "unauthorizedOrganizations",
+        "createdAt",
+        "expiresAt"
+    ];
+
+    public const RESPONSE_TO_RESOURCE_KEY = [
+        "object" => "object",
+        "id" => "id",
+        "token" => "token",
+        "authorized_organizations" => "authorizedOrganizations",
+        "unauthorized_organizations" => "unauthorizedOrganizations",
+        "created_at" => "createdAt",
+        "expires_at" => "expiresAt"
+    ];
+}

--- a/lib/Resource/SessionAndUser.php
+++ b/lib/Resource/SessionAndUser.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class SessionAndUser.
+ *
+ * @property Session  $session
+ * @property User $user
+ */
+class SessionAndUser extends BaseWorkOSResource
+{
+    public const RESOURCE_ATTRIBUTES = [
+        "session",
+        "user"
+    ];
+
+    public const RESPONSE_TO_RESOURCE_KEY = [];
+
+    public static function constructFromResponse($response)
+    {
+        $instance = parent::constructFromResponse($response);
+
+        $instance->values["session"] = Session::constructFromResponse($response["session"]);
+        $instance->values["user"] = User::constructFromResponse($response["user"]);
+
+        return $instance;
+    }
+}

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -54,6 +54,10 @@ class UserManagement
      */
     public function authenticateUserWithPassword($clientId, $email, $password, $ipAddress = null, $userAgent = null, $expiresIn = null)
     {
+        if (!$expiresIn) {
+            $expiresIn = self::DEFAULT_TOKEN_EXPIRATION;
+        }
+
         $authenticateUserWithPasswordPath = "users/sessions/token";
         $params = [
             "client_id" => $clientId,

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -8,6 +8,7 @@ namespace WorkOS;
 class UserManagement
 {
     public const DEFAULT_PAGE_SIZE = 10;
+    public const DEFAULT_TOKEN_EXPIRATION = 1440;
 
     /**
      * Add a user to an organization.
@@ -36,6 +37,108 @@ class UserManagement
         );
 
         return Resource\User::constructFromResponse($response);
+    }
+
+    /**
+     * Authenticate a User with Password
+     *
+     * @param string $clientId This value can be obtained from the Configuration page in the WorkOS dashboard.
+     * @param string $email The email address of the user.
+     * @param string $password The password of the user.
+     * @param string|null $ipAddress The IP address of the request from the user who is attempting to authenticate.
+     * @param string|null $userAgent The user agent of the request from the user who is attempting to authenticate.
+     * @param int|null $expiresIn The length of the session in minutes. Defaults to 1 day, 1440.
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\SessionAndUser
+     */
+    public function authenticateUserWithPassword($clientId, $email, $password, $ipAddress = null, $userAgent = null, $expiresIn = null)
+    {
+        $authenticateUserWithPasswordPath = "users/sessions/token";
+        $params = [
+            "client_id" => $clientId,
+            "email" => $email,
+            "password" => $password,
+            "ip_address" => $ipAddress,
+            "user_agent" => $userAgent,
+            "expires_in" => self::DEFAULT_TOKEN_EXPIRATION,
+            "grant_type" => "password",
+            "client_secret" => WorkOS::getApiKey()
+        ];
+
+        $response = Client::request(Client::METHOD_POST, $authenticateUserWithPasswordPath, null, $params, true);
+
+        return Resource\SessionAndUser::constructFromResponse($response);
+    }
+
+    /**
+     * Authenticate an OAuth or SSO User with a Code
+     *
+     * @param string $clientId This value can be obtained from the Configuration page in the WorkOS dashboard.
+     * @param string $code The authorization value which was passed back as a query parameter in the callback to the Redirect URI.
+     * @param string|null $ipAddress The IP address of the request from the user who is attempting to authenticate.
+     * @param string|null $userAgent The user agent of the request from the user who is attempting to authenticate.
+     * @param int|null $expiresIn The length of the session in minutes. Defaults to 1 day, 1440.
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\SessionAndUser
+     */
+    public function authenticateUserWithCode($clientId, $code, $ipAddress = null, $userAgent = null, $expiresIn = null)
+    {
+        if (!$expiresIn) {
+            $expiresIn = self::DEFAULT_TOKEN_EXPIRATION;
+        }
+
+        $authenticateUserWithCodePath = "users/sessions/token";
+        $params = [
+            "client_id" => $clientId,
+            "code" => $code,
+            "ip_address" => $ipAddress,
+            "user_agent" => $userAgent,
+            "expires_in" => $expiresIn,
+            "grant_type" => "authorization_code",
+            "client_secret" => WorkOS::getApiKey()
+        ];
+
+        $response = Client::request(Client::METHOD_POST, $authenticateUserWithCodePath, null, $params, true);
+
+        return Resource\SessionAndUser::constructFromResponse($response);
+    }
+
+    /**
+     * Authenticate an OAuth or SSO User with a Code
+     *
+     * @param string $clientId This value can be obtained from the Configuration page in the WorkOS dashboard.
+     * @param string $code The authorization value which was passed back as a query parameter in the callback to the Redirect URI.
+     * @param string $magicAuthChallengeId The challenge ID returned from when the one-time code was sent to the user.
+     * @param string|null $ipAddress The IP address of the request from the user who is attempting to authenticate.
+     * @param string|null $userAgent The user agent of the request from the user who is attempting to authenticate.
+     * @param int|null $expiresIn The length of the session in minutes. Defaults to 1 day, 1440.
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\SessionAndUser
+     */
+    public function authenticateUserWithMagicAuth($clientId, $code, $magicAuthChallengeId, $ipAddress = null, $userAgent = null, $expiresIn = null)
+    {
+        if (!$expiresIn) {
+            $expiresIn = self::DEFAULT_TOKEN_EXPIRATION;
+        }
+
+        $authenticateUserWithMagicAuthPath = "users/sessions/token";
+        $params = [
+            "client_id" => $clientId,
+            "code" => $code,
+            "magic_auth_challenge_id" => $magicAuthChallengeId,
+            "ip_address" => $ipAddress,
+            "user_agent" => $userAgent,
+            "expires_in" => $expiresIn,
+            "grant_type" => "urn:workos:oauth:grant-type:magic-auth:code",
+            "client_secret" => WorkOS::getApiKey()
+        ];
+
+        $response = Client::request(Client::METHOD_POST, $authenticateUserWithMagicAuthPath, null, $params, true);
+
+        return Resource\SessionAndUser::constructFromResponse($response);
     }
 
     /**

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -110,7 +110,7 @@ class UserManagement
     }
 
     /**
-     * Authenticate an OAuth or SSO User with a Code
+     * Authenticate with Magic Auth
      *
      * @param string $clientId This value can be obtained from the Configuration page in the WorkOS dashboard.
      * @param string $code The authorization value which was passed back as a query parameter in the callback to the Redirect URI.

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -65,7 +65,7 @@ class UserManagement
             "password" => $password,
             "ip_address" => $ipAddress,
             "user_agent" => $userAgent,
-            "expires_in" => self::DEFAULT_TOKEN_EXPIRATION,
+            "expires_in" => $expiresIn,
             "grant_type" => "password",
             "client_secret" => WorkOS::getApiKey()
         ];

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -42,6 +42,107 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($user, $response->toArray());
     }
 
+    public function testAuthenticateUserWithPassword()
+    {
+        $usersPath = "users/sessions/token";
+        WorkOS::setApiKey("sk_test_12345");
+        $result = $this->createSessionAndUserResponseFixture();
+
+        $params = [
+            "client_id" => "project_0123456",
+            "email" => "marcelina@foo-corp.com",
+            "password" => "i8uv6g34kd490s",
+            "ip_address" => null,
+            "user_agent" => null,
+            "expires_in" => 1440,
+            "grant_type" => "password",
+            "client_secret" => Workos::getApiKey()
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $usersPath,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $userFixture = $this->userFixture();
+        $sessionFixture = $this->sessionFixture();
+
+        $response = $this->userManagement->authenticateUserWithPassword("project_0123456", "marcelina@foo-corp.com", "i8uv6g34kd490s");
+        $this->assertSame($sessionFixture, $response->session->toArray());
+        $this->assertSame($userFixture, $response->user->toArray());
+    }
+
+    public function testAuthenticateUserWithCode()
+    {
+        $usersPath = "users/sessions/token";
+        WorkOS::setApiKey("sk_test_12345");
+        $result = $this->createSessionAndUserResponseFixture();
+
+        $params = [
+            "client_id" => "project_0123456",
+            "code" => "01E2RJ4C05B52KKZ8FSRDAP23J",
+            "ip_address" => null,
+            "user_agent" => null,
+            "expires_in" => 1440,
+            "grant_type" => "authorization_code",
+            "client_secret" => Workos::getApiKey()
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $usersPath,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $userFixture = $this->userFixture();
+        $sessionFixture = $this->sessionFixture();
+
+        $response = $this->userManagement->authenticateUserWithCode("project_0123456", "01E2RJ4C05B52KKZ8FSRDAP23J");
+        $this->assertSame($sessionFixture, $response->session->toArray());
+        $this->assertSame($userFixture, $response->user->toArray());
+    }
+
+    public function testAuthenticateUserWithMagicAuth()
+    {
+        $usersPath = "users/sessions/token";
+        WorkOS::setApiKey("sk_test_12345");
+        $result = $this->createSessionAndUserResponseFixture();
+
+        $params = [
+            "client_id" => "project_0123456",
+            "code" => "123456",
+            "magic_auth_challenge_id" => "auth_challenge_123",
+            "ip_address" => null,
+            "user_agent" => null,
+            "expires_in" => 1440,
+            "grant_type" => "urn:workos:oauth:grant-type:magic-auth:code",
+            "client_secret" => Workos::getApiKey()
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $usersPath,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $userFixture = $this->userFixture();
+        $sessionFixture = $this->sessionFixture();
+
+        $response = $this->userManagement->authenticateUserWithMagicAuth("project_0123456", "123456", "auth_challenge_123");
+        $this->assertSame($sessionFixture, $response->session->toArray());
+        $this->assertSame($userFixture, $response->user->toArray());
+    }
+
     public function testCreateUser()
     {
         $usersPath = "users";
@@ -246,6 +347,39 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
+    private function createSessionAndUserResponseFixture()
+    {
+        return json_encode([
+            "session" => [
+                "object" => "session",
+                "id" => "session_01E4ZCR3C56J083X43JQXF3JK5",
+                "token" => "session_token_123abc",
+                "authorized_organizations" => [
+                    "organization" => [
+                        "id" => "org_01E4ZCR3C56J083X43JQXF3JK5",
+                        "name" => "Foo Corp"
+                    ]
+                ],
+                "unauthorized_organizations" => [],
+                "created_at" => "2021-06-25T19:07:33.155Z",
+                "expires_at" => "2021-06-25T19:07:33.155Z"
+            ],
+            "user" => [
+                "object" => "user",
+                "id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
+                "user_type" => "unmanaged",
+                "email" => "test@test.com",
+                "first_name" => "Damien",
+                "last_name" => "Alabaster",
+                "email_verified_at" => "2021-07-25T19:07:33.155Z",
+                "sso_profile_id" => "1AO5ZPQDE43",
+                "google_oauth_profile_id" => "goog_123ABC",
+                "created_at" => "2021-06-25T19:07:33.155Z",
+                "updated_at" => "2021-06-25T19:07:33.155Z"
+            ]
+        ]);
+    }
+
     private function addUserToOrganizationResponseFixture()
     {
         return json_encode([
@@ -355,6 +489,23 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    private function sessionFixture()
+    {
+        return [
+            "object" => "session",
+            "id" => "session_01E4ZCR3C56J083X43JQXF3JK5",
+            "token" => "session_token_123abc",
+            "authorizedOrganizations" => [
+                "organization" => [
+                    "id" => "org_01E4ZCR3C56J083X43JQXF3JK5",
+                    "name" => "Foo Corp"
+                ]
+            ],
+            "unauthorizedOrganizations" => [],
+            "createdAt" => "2021-06-25T19:07:33.155Z",
+            "expiresAt" => "2021-06-25T19:07:33.155Z"
+        ];
+    }
     private function userFixture()
     {
         return [


### PR DESCRIPTION
## Description
Adds the User Management -> Session -> Authenticate User suite of functions:
Authenticate a User with Password: https://workos.com/docs/reference/user-management/session/authenticate-password
Authenticate an OAuth or SSO User: https://workos.com/docs/reference/user-management/session/authenticate-oauth-sso
Authenticate with Magic Auth: https://workos.com/docs/reference/user-management/session/authenticate-magic-auth

Also resolves USRLD-705, USRLD-710
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
