### PR TITLE
Add `createPasswordResetChallenge` and `completePasswordReset` functions

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -124,6 +124,55 @@ class UserManagement
         return Resource\User::constructFromResponse($response);
     }
 
+    /**
+     * Create Password Reset Challenge.
+     *
+     * @param string $email The email of the user that wishes to reset their password.
+     * @param string $passwordResetUrl The URL that will be linked to in the email.
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\UserAndToken
+     */
+    public function createPasswordResetChallenge($email, $passwordResetUrl)
+    {
+        $createPasswordResetChallengePath = "users/password_reset_challenge";
+
+        $params = [
+            "email" => $email,
+            "password_reset_url" => $passwordResetUrl
+        ];
+
+        $response = Client::request(Client::METHOD_POST, $createPasswordResetChallengePath, null, $params, true);
+
+        return Resource\UserAndToken::constructFromResponse($response);
+    }
+
+    /**
+     * Complete Password Reset.
+     *
+     * @param string $token The reset token emailed to the user.
+     * @param string $newPassword The new password to be set for the user.
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\User
+     */
+    public function completePasswordReset($token, $newPassword)
+    {
+        $completePasswordResetPath = "users/password_reset";
+
+        $params = [
+            "token" => $token,
+            "new_password" => $newPassword
+        ];
+
+        $response = Client::request(Client::METHOD_POST, $completePasswordResetPath, null, $params, true);
+
+        return Resource\User::constructFromResponse($response);
+    }
+
+
 
     /**
      * List Users.

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -121,6 +121,61 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($user, $response->toArray());
     }
 
+    public function testCreatePasswordResetChallenge()
+    {
+        $createPasswordResetChallengePath = "users/password_reset_challenge";
+
+        $result = $this->createUserAndTokenResponseFixture();
+
+        $params = [
+            "email" => "test@test.com",
+            "password_reset_url" => "https://your-app.com/reset-password"
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $createPasswordResetChallengePath,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+
+        $userFixture = $this->userFixture();
+
+        $response = $this->userManagement->createPasswordResetChallenge("test@test.com", "https://your-app.com/reset-password");
+        $this->assertSame("01DMEK0J53CVMC32CK5SE0KZ8Q", $response->token);
+        $this->assertSame($userFixture, $response->user->toArray());
+    }
+
+    public function testCompletePasswordReset()
+    {
+        $completePasswordResetPath = "users/password_reset";
+
+        $result = $this->createUserResponseFixture();
+
+        $params = [
+            "token" => "01DMEK0J53CVMC32CK5SE0KZ8Q",
+            "new_password" => "^O9w8hiZu3x!"
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $completePasswordResetPath,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $user = $this->userFixture();
+
+        $response = $this->userManagement->completePasswordReset("01DMEK0J53CVMC32CK5SE0KZ8Q", "^O9w8hiZu3x!");
+        $this->assertSame($user, $response->toArray());
+    }
+
+
 
     public function testGetUser()
     {


### PR DESCRIPTION
## Description
Adds User Management Password Reset suite of functions
https://workos.com/docs/reference/user-management/password-reset

Create Password Reset Challenge
https://workos.com/docs/reference/user-management/password-reset/challenge

Complete Password Reset Challenge
https://workos.com/docs/reference/user-management/password-reset/complete
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
