### PR TITLE
Updates `email_verified`, `*_profile_ids`, and `user_type` on `User` object

### DIFF
--- a/lib/Resource/User.php
+++ b/lib/Resource/User.php
@@ -12,13 +12,10 @@ class User extends BaseWorkOSResource
     public const RESOURCE_ATTRIBUTES = [
         "object",
         "id",
-        "userType",
         "email",
         "firstName",
         "lastName",
-        "emailVerifiedAt",
-        "googleOauthProfileId",
-        "ssoProfileId",
+        "emailVerified",
         "createdAt",
         "updatedAt"
     ];
@@ -26,13 +23,10 @@ class User extends BaseWorkOSResource
     public const RESPONSE_TO_RESOURCE_KEY = [
         "object" => "object",
         "id" => "id",
-        "user_type" => "userType",
         "email" => "email",
         "first_name" => "firstName",
         "last_name" => "lastName",
-        "email_verified_at" => "emailVerifiedAt",
-        "google_oauth_profile_id" => "googleOauthProfileId",
-        "sso_profile_id" => "ssoProfileId",
+        "email_verified" => "emailVerified",
         "created_at" => "createdAt",
         "updated_at" => "updatedAt"
     ];

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -284,7 +284,6 @@ class UserManagement
     /**
      * List Users.
      *
-     * @param null|string $type User type "unmanaged" or "managed"
      * @param null|string $email
      * @param null|string $organization Organization users are a member of
      * @param int $limit Maximum number of records to return
@@ -300,7 +299,6 @@ class UserManagement
      *      array \WorkOS\Resource\User instances
      */
     public function listUsers(
-        $type = null,
         $email = null,
         $organization = null,
         $limit = self::DEFAULT_PAGE_SIZE,
@@ -310,7 +308,6 @@ class UserManagement
     ) {
         $usersPath = "users";
         $params = [
-            "type" => $type,
             "email" => $email,
             "organization" => $organization,
             "limit" => $limit,

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -305,7 +305,6 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     {
         $usersPath = "users";
         $params = [
-            "type" => null,
             "email" => null,
             "organization" => null,
             "limit" => UserManagement::DEFAULT_PAGE_SIZE,
@@ -386,13 +385,11 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "user" => [
                 "object" => "user",
                 "id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
-                "user_type" => "unmanaged",
+
                 "email" => "test@test.com",
                 "first_name" => "Damien",
                 "last_name" => "Alabaster",
-                "email_verified_at" => "2021-07-25T19:07:33.155Z",
-                "sso_profile_id" => "1AO5ZPQDE43",
-                "google_oauth_profile_id" => "goog_123ABC",
+                "email_verified" => true,
                 "created_at" => "2021-06-25T19:07:33.155Z",
                 "updated_at" => "2021-06-25T19:07:33.155Z"
             ]
@@ -419,13 +416,10 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "user" => [
                 "object" => "user",
                 "id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
-                "user_type" => "unmanaged",
                 "email" => "test@test.com",
                 "first_name" => "Damien",
                 "last_name" => "Alabaster",
-                "email_verified_at" => "2021-07-25T19:07:33.155Z",
-                "sso_profile_id" => "1AO5ZPQDE43",
-                "google_oauth_profile_id" => "goog_123ABC",
+                "email_verified" => true,
                 "created_at" => "2021-06-25T19:07:33.155Z",
                 "updated_at" => "2021-06-25T19:07:33.155Z"
             ]
@@ -437,13 +431,10 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         return json_encode([
             "object" => "user",
             "id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
-            "user_type" => "unmanaged",
             "email" => "test@test.com",
             "first_name" => "Damien",
             "last_name" => "Alabaster",
-            "email_verified_at" => "2021-07-25T19:07:33.155Z",
-            "sso_profile_id" => "1AO5ZPQDE43",
-            "google_oauth_profile_id" => "goog_123ABC",
+            "email_verified" => true,
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z"
         ]);
@@ -454,13 +445,10 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         return json_encode([
             "object" => "user",
             "id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
-            "user_type" => "unmanaged",
             "email" => "test@test.com",
             "first_name" => "Damien",
             "last_name" => "Alabaster",
-            "email_verified_at" => "2021-07-25T19:07:33.155Z",
-            "sso_profile_id" => "1AO5ZPQDE43",
-            "google_oauth_profile_id" => "goog_123ABC",
+            "email_verified" => true,
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z"
         ]);
@@ -479,13 +467,10 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         return json_encode([
             "object" => "user",
             "id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
-            "user_type" => "unmanaged",
             "email" => "test@test.com",
             "first_name" => "Damien",
             "last_name" => "Alabaster",
-            "email_verified_at" => "2021-07-25T19:07:33.155Z",
-            "sso_profile_id" => "1AO5ZPQDE43",
-            "google_oauth_profile_id" => "goog_123ABC",
+            "email_verified" => true,
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z"
         ]);
@@ -498,13 +483,10 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
                 [
                     "object" => "user",
                     "id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
-                    "user_type" => "unmanaged",
                     "email" => "test@test.com",
                     "first_name" => "Damien",
                     "last_name" => "Alabaster",
-                    "email_verified_at" => "2021-07-25T19:07:33.155Z",
-                    "sso_profile_id" => "1AO5ZPQDE43",
-                    "google_oauth_profile_id" => "goog_123ABC",
+                    "email_verified" => true,
                     "created_at" => "2021-06-25T19:07:33.155Z",
                     "updated_at" => "2021-06-25T19:07:33.155Z"
                 ]
@@ -521,13 +503,10 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         return json_encode([
             "object" => "user",
             "id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
-            "user_type" => "unmanaged",
             "email" => "test@test.com",
             "first_name" => "Damien",
             "last_name" => "Alabaster",
-            "email_verified_at" => "2021-07-25T19:07:33.155Z",
-            "sso_profile_id" => "1AO5ZPQDE43",
-            "google_oauth_profile_id" => "goog_123ABC",
+            "email_verified" => true,
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z"
         ]);
@@ -563,13 +542,10 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         return [
             "object" => "user",
             "id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
-            "userType" => "unmanaged",
             "email" => "test@test.com",
             "firstName" => "Damien",
             "lastName" => "Alabaster",
-            "emailVerifiedAt" => "2021-07-25T19:07:33.155Z",
-            "googleOauthProfileId" => "goog_123ABC",
-            "ssoProfileId" => "1AO5ZPQDE43",
+            "emailVerified" => true,
             "createdAt" => "2021-06-25T19:07:33.155Z",
             "updatedAt" => "2021-06-25T19:07:33.155Z"
         ];

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -385,7 +385,6 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "user" => [
                 "object" => "user",
                 "id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
-
                 "email" => "test@test.com",
                 "first_name" => "Damien",
                 "last_name" => "Alabaster",


### PR DESCRIPTION
## Description
Renames email_verified_at to email_verified on User object. New type is boolean

Removes *_profile_id fields from User object

Removes user_type from User object

Removes type argument from listUsers
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
