### PR TITLE
Update `authenticateWithMagicAuth` to use `$userId`

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -114,7 +114,7 @@ class UserManagement
      *
      * @param string $clientId This value can be obtained from the Configuration page in the WorkOS dashboard.
      * @param string $code The authorization value which was passed back as a query parameter in the callback to the Redirect URI.
-     * @param string $magicAuthChallengeId The challenge ID returned from when the one-time code was sent to the user.
+     * @param string $userId The user ID returned from the Magic Auth challenge.
      * @param string|null $ipAddress The IP address of the request from the user who is attempting to authenticate.
      * @param string|null $userAgent The user agent of the request from the user who is attempting to authenticate.
      * @param int|null $expiresIn The length of the session in minutes. Defaults to 1 day, 1440.
@@ -122,7 +122,7 @@ class UserManagement
      *
      * @return \WorkOS\Resource\SessionAndUser
      */
-    public function authenticateUserWithMagicAuth($clientId, $code, $magicAuthChallengeId, $ipAddress = null, $userAgent = null, $expiresIn = null)
+    public function authenticateUserWithMagicAuth($clientId, $code, $userId, $ipAddress = null, $userAgent = null, $expiresIn = null)
     {
         if (!$expiresIn) {
             $expiresIn = self::DEFAULT_TOKEN_EXPIRATION;
@@ -132,7 +132,7 @@ class UserManagement
         $params = [
             "client_id" => $clientId,
             "code" => $code,
-            "magic_auth_challenge_id" => $magicAuthChallengeId,
+            "user_id" => $userId,
             "ip_address" => $ipAddress,
             "user_agent" => $userAgent,
             "expires_in" => $expiresIn,

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -118,7 +118,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $params = [
             "client_id" => "project_0123456",
             "code" => "123456",
-            "magic_auth_challenge_id" => "auth_challenge_123",
+            "user_id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
             "ip_address" => null,
             "user_agent" => null,
             "expires_in" => 1440,
@@ -138,7 +138,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $userFixture = $this->userFixture();
         $sessionFixture = $this->sessionFixture();
 
-        $response = $this->userManagement->authenticateUserWithMagicAuth("project_0123456", "123456", "auth_challenge_123");
+        $response = $this->userManagement->authenticateUserWithMagicAuth("project_0123456", "123456", "user_01H7X1M4TZJN5N4HG4XXMA1234");
         $this->assertSame($sessionFixture, $response->session->toArray());
         $this->assertSame($userFixture, $response->user->toArray());
     }


### PR DESCRIPTION
## Description
Changes a parameter of authenticateWithMagicAuth to use $userId instead of a magicAuthCode.
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
