### PR TITLE
Update `verifyEmail` path and change name to `verifyEmailCode`

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -200,16 +200,16 @@ class UserManagement
      *
      * @return \WorkOS\Resource\User
      */
-    public function verifyEmail($userId, $code)
+    public function verifyEmailCode($userId, $code)
     {
-        $verifyEmailPath = "users/{$userId}/verify_email";
+        $verifyEmailCodePath = "users/{$userId}/verify_email_code";
 
         $params = [
             "user_id" => $userId,
             "code" => $code
         ];
 
-        $response = Client::request(Client::METHOD_POST, $verifyEmailPath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $verifyEmailCodePath, null, $params, true);
 
         return Resource\User::constructFromResponse($response);
     }

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -240,7 +240,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public function testVerifyEmailCode()
     {
         $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";
-        $usersPath = "users/{$userId}/verify_email_code";
+        $verifyEmailCodePath = "users/{$userId}/verify_email_code";
 
         $result = $this->createUserResponseFixture();
 
@@ -251,7 +251,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->mockRequest(
             Client::METHOD_POST,
-            $usersPath,
+            $verifyEmailCodePath,
             null,
             $params,
             true,

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -237,10 +237,10 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($user, $response->toArray());
     }
 
-    public function testVerifyEmail()
+    public function testVerifyEmailCode()
     {
         $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";
-        $usersPath = "users/{$userId}/verify_email";
+        $usersPath = "users/{$userId}/verify_email_code";
 
         $result = $this->createUserResponseFixture();
 
@@ -260,7 +260,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $user = $this->userFixture();
 
-        $response = $this->userManagement->verifyEmail("user_01H7X1M4TZJN5N4HG4XXMA1234", "01DMEK0J53CVMC32CK5SE0KZ8Q");
+        $response = $this->userManagement->verifyEmailCode("user_01H7X1M4TZJN5N4HG4XXMA1234", "01DMEK0J53CVMC32CK5SE0KZ8Q");
         $this->assertSame($user, $response->toArray());
     }
 


### PR DESCRIPTION
## Description
Changes the `verifyEmail` function path from `users/{$userId}/verify_email` to `users/{$userId}/verify_email_code`

Changes the name of the `verifyEmail` function to `verifyEmailCode`
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
