### PR TITLE
Add updateUser function

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -391,6 +391,33 @@ class UserManagement
     }
 
     /**
+     * Update a User
+     *
+     * @param string $userId The unique ID of the user.
+     * @param string|null $firstName The first name of the user.
+     * @param string|null $lastName The last name of the user.
+     * @param boolean|null $emailVerified A boolean declaring if the user's email has been verified.
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\User
+     */
+    public function updateUser($userId, $firstName, $lastName, $emailVerified)
+    {
+        $usersPath = "users/{$userId}";
+
+        $params = [
+            "first_name" => $firstName,
+            "last_name" => $lastName,
+            "email_verified" => $emailVerified
+        ];
+
+        $response = Client::request(Client::METHOD_PUT, $usersPath, null, $params, true);
+
+        return Resource\User::constructFromResponse($response);
+    }
+
+    /**
      * Update a User's password.
      *
      * @param string $userId The unique ID of the user.

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -38,6 +38,34 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($response, []);
     }
 
+    public function testUpdateUser()
+    {
+        $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";
+        $usersPath = "users/{$userId}";
+
+        $result = $this->createUserResponseFixture();
+
+        $params = [
+            "first_name" => "Damien",
+            "last_name" => "Alabaster",
+            "email_verified" => true
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_PUT,
+            $usersPath,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $user = $this->userFixture();
+
+        $response = $this->userManagement->updateUser("user_01H7X1M4TZJN5N4HG4XXMA1234", "Damien", "Alabaster", true);
+        $this->assertSame($user, $response->toArray());
+    }
+
     public function testUpdateUserPassword()
     {
         $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";


### PR DESCRIPTION
## Description
Adds the `updateUser` function.
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
