### PR TITLE
Append 'password' to updateUserPassword path

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -402,7 +402,7 @@ class UserManagement
      */
     public function updateUserPassword($userId, $password)
     {
-        $usersPath = "users/{$userId}";
+        $usersPath = "users/{$userId}/password";
 
         $params = [
             "password" => $password

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -41,7 +41,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public function testUpdateUserPassword()
     {
         $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";
-        $usersPath = "users/{$userId}";
+        $usersPath = "users/{$userId}/password";
 
         $result = $this->createUserResponseFixture();
 


### PR DESCRIPTION
## Description
Change path of `updateUserPassword from `users/{$userId}` to `users/{$userId}/password`
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
