### PR TITLE
Makes non userId params nullable on updateUser

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -402,7 +402,7 @@ class UserManagement
      *
      * @return \WorkOS\Resource\User
      */
-    public function updateUser($userId, $firstName, $lastName, $emailVerified)
+    public function updateUser($userId, $firstName = null, $lastName = null, $emailVerified = null)
     {
         $usersPath = "users/{$userId}";
 


### PR DESCRIPTION
## Description
QAing params in SDK and noticed docs (https://workos.com/docs/reference/user-management/user/update) correctly reflect firstName, lastName, and emailVerified as optional, but SDK does not. 
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
