### PR TITLE
Update nested user object in return

### DIFF
--- a/lib/Resource/UserResponse.php
+++ b/lib/Resource/UserResponse.php
@@ -3,11 +3,11 @@
 namespace WorkOS\Resource;
 
 /**
- * Class AuthenticateUserResponse.
+ * Class UserResponse.
  *
  * @property User $user
  */
-class AuthenticateUserResponse extends BaseWorkOSResource
+class UserResponse extends BaseWorkOSResource
 {
     public const RESOURCE_ATTRIBUTES = [
         "user"

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -66,7 +66,7 @@ class UserManagement
 
         $response = Client::request(Client::METHOD_POST, $authenticateUserWithPasswordPath, null, $params, true);
 
-        return Resource\AuthenticateUserResponse::constructFromResponse($response);
+        return Resource\UserResponse::constructFromResponse($response);
     }
 
     /**
@@ -94,7 +94,7 @@ class UserManagement
 
         $response = Client::request(Client::METHOD_POST, $authenticateUserWithCodePath, null, $params, true);
 
-        return Resource\AuthenticateUserResponse::constructFromResponse($response);
+        return Resource\UserResponse::constructFromResponse($response);
     }
 
     /**
@@ -125,7 +125,7 @@ class UserManagement
 
         $response = Client::request(Client::METHOD_POST, $authenticateUserWithMagicAuthPath, null, $params, true);
 
-        return Resource\AuthenticateUserResponse::constructFromResponse($response);
+        return Resource\UserResponse::constructFromResponse($response);
     }
 
     /**
@@ -211,7 +211,7 @@ class UserManagement
 
         $response = Client::request(Client::METHOD_POST, $verifyEmailCodePath, null, $params, true);
 
-        return Resource\User::constructFromResponse($response);
+        return Resource\UserResponse::constructFromResponse($response);
     }
 
     /**

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -215,7 +215,7 @@ class UserManagement
     }
 
     /**
-     * Create Password Reset Challenge.
+     * Create Password Reset Email.
      *
      * @param string $email The email of the user that wishes to reset their password.
      * @param string $passwordResetUrl The URL that will be linked to in the email.
@@ -224,16 +224,16 @@ class UserManagement
      *
      * @return \WorkOS\Resource\UserAndToken
      */
-    public function createPasswordResetChallenge($email, $passwordResetUrl)
+    public function sendPasswordResetEmail($email, $passwordResetUrl)
     {
-        $createPasswordResetChallengePath = "users/password_reset_challenge";
+        $sendPasswordResetEmailPath = "users/send_password_reset_email";
 
         $params = [
             "email" => $email,
             "password_reset_url" => $passwordResetUrl
         ];
 
-        $response = Client::request(Client::METHOD_POST, $createPasswordResetChallengePath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $sendPasswordResetEmailPath, null, $params, true);
 
         return Resource\UserAndToken::constructFromResponse($response);
     }
@@ -248,18 +248,18 @@ class UserManagement
      *
      * @return \WorkOS\Resource\User
      */
-    public function completePasswordReset($token, $newPassword)
+    public function resetPassword($token, $newPassword)
     {
-        $completePasswordResetPath = "users/password_reset";
+        $resetPasswordPath = "users/password_reset";
 
         $params = [
             "token" => $token,
             "new_password" => $newPassword
         ];
 
-        $response = Client::request(Client::METHOD_POST, $completePasswordResetPath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $resetPasswordPath, null, $params, true);
 
-        return Resource\User::constructFromResponse($response);
+        return Resource\UserResponse::constructFromResponse($response);
     }
 
 

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -49,7 +49,7 @@ class UserManagement
      * @param string|null $userAgent The user agent of the request from the user who is attempting to authenticate.
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\User
+     * @return \WorkOS\Resource\UserResponse
      */
     public function authenticateUserWithPassword($clientId, $email, $password, $ipAddress = null, $userAgent = null)
     {
@@ -78,7 +78,7 @@ class UserManagement
      * @param string|null $userAgent The user agent of the request from the user who is attempting to authenticate.
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\User
+     * @return \WorkOS\Resource\UserResponse
      */
     public function authenticateUserWithCode($clientId, $code, $ipAddress = null, $userAgent = null)
     {
@@ -107,7 +107,7 @@ class UserManagement
      * @param string|null $userAgent The user agent of the request from the user who is attempting to authenticate.
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\User
+     * @return \WorkOS\Resource\UserResponse
      */
 
     public function authenticateUserWithMagicAuth($clientId, $code, $userId, $ipAddress = null, $userAgent = null)
@@ -198,7 +198,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\User
+     * @return \WorkOS\Resource\UserResponse
      */
     public function verifyEmailCode($userId, $code)
     {

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -246,7 +246,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\User
+     * @return \WorkOS\Resource\UserResponse
      */
     public function resetPassword($token, $newPassword)
     {

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -124,7 +124,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     {
         $usersPath = "users/authenticate";
         WorkOS::setApiKey("sk_test_12345");
-        $result = $this->authenticateUserResponseFixture();
+        $result = $this->UserResponseFixture();
 
         $params = [
             "client_id" => "project_0123456",
@@ -155,7 +155,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     {
         $usersPath = "users/authenticate";
         WorkOS::setApiKey("sk_test_12345");
-        $result = $this->authenticateUserResponseFixture();
+        $result = $this->UserResponseFixture();
 
         $params = [
             "client_id" => "project_0123456",
@@ -185,7 +185,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     {
         $usersPath = "users/authenticate";
         WorkOS::setApiKey("sk_test_12345");
-        $result = $this->authenticateUserResponseFixture();
+        $result = $this->UserResponseFixture();
 
         $params = [
             "client_id" => "project_0123456",
@@ -270,7 +270,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";
         $verifyEmailCodePath = "users/{$userId}/verify_email_code";
 
-        $result = $this->createUserResponseFixture();
+        $result = $this->UserResponseFixture();
 
         $params = [
             "user_id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
@@ -286,10 +286,10 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             $result
         );
 
-        $user = $this->userFixture();
+        $userFixture = $this->userFixture();
 
         $response = $this->userManagement->verifyEmailCode("user_01H7X1M4TZJN5N4HG4XXMA1234", "01DMEK0J53CVMC32CK5SE0KZ8Q");
-        $this->assertSame($user, $response->toArray());
+        $this->assertSame($userFixture, $response->user->toArray());
     }
 
     public function testCreatePasswordResetChallenge()
@@ -448,7 +448,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     }
     // Fixtures
 
-    private function authenticateUserResponseFixture()
+    private function UserResponseFixture()
     {
         return json_encode([
             "user" => [

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -448,7 +448,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     }
     // Fixtures
 
-    private function UserResponseFixture()
+    private function userResponseFixture()
     {
         return json_encode([
             "user" => [

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -292,9 +292,9 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($userFixture, $response->user->toArray());
     }
 
-    public function testCreatePasswordResetChallenge()
+    public function testSendPasswordResetEmail()
     {
-        $createPasswordResetChallengePath = "users/password_reset_challenge";
+        $sendPasswordResetEmailPath = "users/send_password_reset_email";
 
         $result = $this->createUserAndTokenResponseFixture();
 
@@ -305,7 +305,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->mockRequest(
             Client::METHOD_POST,
-            $createPasswordResetChallengePath,
+            $sendPasswordResetEmailPath,
             null,
             $params,
             true,
@@ -315,16 +315,16 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $userFixture = $this->userFixture();
 
-        $response = $this->userManagement->createPasswordResetChallenge("test@test.com", "https://your-app.com/reset-password");
+        $response = $this->userManagement->sendPasswordResetEmail("test@test.com", "https://your-app.com/reset-password");
         $this->assertSame("01DMEK0J53CVMC32CK5SE0KZ8Q", $response->token);
         $this->assertSame($userFixture, $response->user->toArray());
     }
 
-    public function testCompletePasswordReset()
+    public function testResetPassword()
     {
-        $completePasswordResetPath = "users/password_reset";
+        $resetPasswordPath = "users/password_reset";
 
-        $result = $this->createUserResponseFixture();
+        $result = $this->userResponseFixture();
 
         $params = [
             "token" => "01DMEK0J53CVMC32CK5SE0KZ8Q",
@@ -333,17 +333,17 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->mockRequest(
             Client::METHOD_POST,
-            $completePasswordResetPath,
+            $resetPasswordPath,
             null,
             $params,
             true,
             $result
         );
 
-        $user = $this->userFixture();
+        $userFixture = $this->userFixture();
 
-        $response = $this->userManagement->completePasswordReset("01DMEK0J53CVMC32CK5SE0KZ8Q", "^O9w8hiZu3x!");
-        $this->assertSame($user, $response->toArray());
+        $response = $this->userManagement->resetPassword("01DMEK0J53CVMC32CK5SE0KZ8Q", "^O9w8hiZu3x!");
+        $this->assertSame($userFixture, $response->user->toArray());
     }
 
 


### PR DESCRIPTION
## Description
Changes `AuthenticateUserResponse` to `UserResponse`. 

Updates response of `verifyEmailCode` from `User` object to `UserResponse` with nested user object. 

Changes `completePasswordReset`  to `resetPassword` 

Updates response of `resetPassword` from `User` object to `UserResponse` with nested user object. 

Changes `createPasswordResetChallenge` to `sendPasswordResetEmail`

Also resolves USRLD-1090, USRLD-1097

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
