### PR TITLE
Add `listAuthFactors`, rename authenticateUser functions

### DIFF
--- a/lib/Resource/UserAuthenticationFactorTotp.php
+++ b/lib/Resource/UserAuthenticationFactorTotp.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class UserAuthenticationFactorTotp.
+ */
+class UserAuthenticationFactorTotp extends BaseWorkOSResource
+{
+    public const RESOURCE_TYPE = "authentication_factor";
+
+    public const RESOURCE_ATTRIBUTES = [
+        "object",
+        "id",
+        "userId",
+        "createdAt",
+        "updatedAt",
+        "type",
+        "totp"
+    ];
+
+    public const RESPONSE_TO_RESOURCE_KEY = [
+        "object" => "object",
+        "id" => "id",
+        "user_id" => "userId",
+        "created_at" => "createdAt",
+        "updated_at" => "updatedAt",
+        "type" => "type",
+        "totp" => "totp"
+    ];
+}

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -51,9 +51,9 @@ class UserManagement
      *
      * @return \WorkOS\Resource\UserResponse
      */
-    public function authenticateUserWithPassword($clientId, $email, $password, $ipAddress = null, $userAgent = null)
+    public function authenticateWithPassword($clientId, $email, $password, $ipAddress = null, $userAgent = null)
     {
-        $authenticateUserWithPasswordPath = "users/authenticate";
+        $authenticateWithPasswordPath = "users/authenticate";
         $params = [
             "client_id" => $clientId,
             "email" => $email,
@@ -64,7 +64,7 @@ class UserManagement
             "client_secret" => WorkOS::getApiKey()
         ];
 
-        $response = Client::request(Client::METHOD_POST, $authenticateUserWithPasswordPath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $authenticateWithPasswordPath, null, $params, true);
 
         return Resource\UserResponse::constructFromResponse($response);
     }
@@ -80,9 +80,9 @@ class UserManagement
      *
      * @return \WorkOS\Resource\UserResponse
      */
-    public function authenticateUserWithCode($clientId, $code, $ipAddress = null, $userAgent = null)
+    public function authenticateWithCode($clientId, $code, $ipAddress = null, $userAgent = null)
     {
-        $authenticateUserWithCodePath = "users/authenticate";
+        $authenticateWithCodePath = "users/authenticate";
         $params = [
             "client_id" => $clientId,
             "code" => $code,
@@ -92,7 +92,7 @@ class UserManagement
             "client_secret" => WorkOS::getApiKey()
         ];
 
-        $response = Client::request(Client::METHOD_POST, $authenticateUserWithCodePath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $authenticateWithCodePath, null, $params, true);
 
         return Resource\UserResponse::constructFromResponse($response);
     }
@@ -110,9 +110,9 @@ class UserManagement
      * @return \WorkOS\Resource\UserResponse
      */
 
-    public function authenticateUserWithMagicAuth($clientId, $code, $userId, $ipAddress = null, $userAgent = null)
+    public function authenticateWithMagicAuth($clientId, $code, $userId, $ipAddress = null, $userAgent = null)
     {
-        $authenticateUserWithMagicAuthPath = "users/authenticate";
+        $authenticateWithMagicAuthPath = "users/authenticate";
         $params = [
             "client_id" => $clientId,
             "code" => $code,
@@ -123,7 +123,7 @@ class UserManagement
             "client_secret" => WorkOS::getApiKey()
         ];
 
-        $response = Client::request(Client::METHOD_POST, $authenticateUserWithMagicAuthPath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $authenticateWithMagicAuthPath, null, $params, true);
 
         return Resource\UserResponse::constructFromResponse($response);
     }
@@ -492,5 +492,29 @@ class UserManagement
         $response = Client::request(Client::METHOD_PUT, $usersPath, null, $params, true);
 
         return Resource\User::constructFromResponse($response);
+    }
+
+    /**
+     * List a User's Authentication Factors.
+     *
+     * @param string $userId The unique ID of the user.
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return array $authFactors An array containing the user's authentication factors as \WorkOS\Resource\UserAuthenticationFactorTotp instances
+     */
+    public function listAuthFactors($userId)
+    {
+        $usersPath = "users/{$userId}/auth/factors";
+
+        $response = Client::request(Client::METHOD_GET, $usersPath, null, null, true);
+
+        $authFactors = [];
+
+        foreach ($response["data"] as $responseData) {
+            \array_push($authFactors, Resource\UserAuthenticationFactorTotp::constructFromResponse($responseData));
+        }
+
+        return $authFactors;
     }
 }

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -120,7 +120,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($user, $response->toArray());
     }
 
-    public function testAuthenticateUserWithPassword()
+    public function testAuthenticateWithPassword()
     {
         $usersPath = "users/authenticate";
         WorkOS::setApiKey("sk_test_12345");
@@ -147,11 +147,11 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $userFixture = $this->userFixture();
 
-        $response = $this->userManagement->authenticateUserWithPassword("project_0123456", "marcelina@foo-corp.com", "i8uv6g34kd490s");
+        $response = $this->userManagement->authenticateWithPassword("project_0123456", "marcelina@foo-corp.com", "i8uv6g34kd490s");
         $this->assertSame($userFixture, $response->user->toArray());
     }
 
-    public function testAuthenticateUserWithCode()
+    public function testAuthenticateWithCode()
     {
         $usersPath = "users/authenticate";
         WorkOS::setApiKey("sk_test_12345");
@@ -177,7 +177,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $userFixture = $this->userFixture();
 
-        $response = $this->userManagement->authenticateUserWithCode("project_0123456", "01E2RJ4C05B52KKZ8FSRDAP23J");
+        $response = $this->userManagement->authenticateWithCode("project_0123456", "01E2RJ4C05B52KKZ8FSRDAP23J");
         $this->assertSame($userFixture, $response->user->toArray());
     }
 
@@ -240,7 +240,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
 
 
-    public function testAuthenticateUserWithMagicAuth()
+    public function testAuthenticateWithMagicAuth()
     {
         $usersPath = "users/authenticate";
         WorkOS::setApiKey("sk_test_12345");
@@ -267,7 +267,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $userFixture = $this->userFixture();
 
-        $response = $this->userManagement->authenticateUserWithMagicAuth("project_0123456", "123456", "user_01H7X1M4TZJN5N4HG4XXMA1234");
+        $response = $this->userManagement->authenticateWithMagicAuth("project_0123456", "123456", "user_01H7X1M4TZJN5N4HG4XXMA1234");
         $this->assertSame($userFixture, $response->user->toArray());
     }
 
@@ -505,7 +505,80 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $response = $this->userManagement->sendMagicAuthCode("test@test.com");
         $this->assertSame($user, $response->toArray());
     }
-    // Fixtures
+
+    public function testListAuthFactors()
+    {
+        $userId = "user_01H96FETWYSJMJEGF0Q3ZB272F";
+        $usersPath = "users/{$userId}/auth/factors";
+
+        $result = $this->listAuthFactorResponseFixture();
+
+        $this->mockRequest(
+            Client::METHOD_GET,
+            $usersPath,
+            null,
+            null,
+            true,
+            $result
+        );
+
+        $authFactors = $this->listAuthFactorFixture();
+        $response = $this->userManagement->listAuthFactors("user_01H96FETWYSJMJEGF0Q3ZB272F");
+        var_dump($response);
+        $this->assertSame($authFactors, $response[0]->toArray());
+    }
+
+    //Fixtures
+
+    private function listAuthFactorResponseFixture()
+    {
+        return json_encode(
+            [
+                "data" => [
+                    [
+                        "object" => "authentication_factor",
+                        "id" => "auth_factor_01FXNWW32G7F3MG8MYK5D1HJJM",
+                        "user_id" => "user_01H96FETWYSJMJEGF0Q3ZB272F",
+                        "created_at" => "2022-03-08T23:12:20.157Z",
+                        "updated_at" => "2022-03-08T23:12:20.157Z",
+                        "type" => "totp",
+                        "totp" => [
+                            "issuer" => "Foo Corp",
+                            "user" => "user@foo-corp.com",
+                        ]
+                    ],
+                    [
+                        "object" => "authentication_factor",
+                        "id" => "auth_factor_01FXNWW32G7F3MG8MYK5D1HJJN",
+                        "user_id" => "user_01H96FETWYSJMJEGF0Q3ZB272F",
+                        "created_at" => "2022-03-08T23:12:20.157Z",
+                        "updated_at" => "2022-03-08T23:12:20.157Z",
+                        "type" => "totp",
+                        "totp" => [
+                            "issuer" => "Bar Corp",
+                            "user" => "user@bar-corp.com"
+                        ]
+                    ]
+                ]
+            ]
+        );
+    }
+
+    private function listAuthFactorFixture()
+    {
+        return [
+            "object" => "authentication_factor",
+            "id" => "auth_factor_01FXNWW32G7F3MG8MYK5D1HJJM",
+            "userId" => "user_01H96FETWYSJMJEGF0Q3ZB272F",
+            "createdAt" => "2022-03-08T23:12:20.157Z",
+            "updatedAt" => "2022-03-08T23:12:20.157Z",
+            "type" => "totp",
+            "totp" => [
+                "issuer" => "Foo Corp",
+                "user" => "user@foo-corp.com",
+            ]
+        ];
+    }
 
     private function userResponseFixture()
     {


### PR DESCRIPTION
## Description
Adds the listAuthFactors function

Renames all authenticateUserWith* functions to authenticateWith*

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
