### PR TITLE
Bump Version to 3.4.0

### DIFF
--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS;
 final class Version
 {
     public const SDK_IDENTIFIER = "WorkOS PHP";
-    public const SDK_VERSION = '3.3.0';
+    public const SDK_VERSION = '3.4.0';
 }


### PR DESCRIPTION
## Description
Bumping version to v3.4.0 to release .gitattributes file. 
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
