### PR TITLE
(chore) Test all supported versions.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        php: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
         stability: [ prefer-lowest, prefer-stable ]
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+name: Tests
+
+on: [ push, pull_request ]
+
+jobs:
+  tests:
+
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: [ '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        stability: [ prefer-lowest, prefer-stable ]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extension-csv: curl
+          coverage: none
+
+      - name: Install dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/phpunit


### PR DESCRIPTION
***DO NOT MERGE FOR NOW***

---

## Description

This PR introduces tests via GA for all supported PHP versions of this package.
It also aims to check some breaking changes introduced by https://github.com/workos/workos-php/pull/178

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
