### PR TITLE
User Management - List Users: Rename organization parameter filter and use new path

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -343,7 +343,8 @@ class UserManagement
         $after = null,
         $order = null
     ) {
-        $usersPath = "users";
+        $usersPath = "user_management/users";
+
         $params = [
             "email" => $email,
             "organization_id" => $organization,
@@ -362,11 +363,10 @@ class UserManagement
         );
 
         $users = [];
+        list($before, $after) = Util\Request::parsePaginationArgs($response);
         foreach ($response["data"] as $responseData) {
             \array_push($users, Resource\User::constructFromResponse($responseData));
         }
-
-        list($before, $after) = Util\Request::parsePaginationArgs($response);
 
         return [$before, $after, $users];
     }

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -346,7 +346,7 @@ class UserManagement
         $usersPath = "users";
         $params = [
             "email" => $email,
-            "organization" => $organization,
+            "organization_id" => $organization,
             "limit" => $limit,
             "before" => $before,
             "after" => $after,
@@ -362,10 +362,11 @@ class UserManagement
         );
 
         $users = [];
-        list($before, $after) = Util\Request::parsePaginationArgs($response);
         foreach ($response["data"] as $responseData) {
             \array_push($users, Resource\User::constructFromResponse($responseData));
         }
+
+        list($before, $after) = Util\Request::parsePaginationArgs($response);
 
         return [$before, $after, $users];
     }

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -435,7 +435,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $usersPath = "users";
         $params = [
             "email" => null,
-            "organization" => null,
+            "organization_id" => null,
             "limit" => UserManagement::DEFAULT_PAGE_SIZE,
             "before" => null,
             "after" => null,

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -432,7 +432,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testListUsers()
     {
-        $usersPath = "users";
+        $usersPath = "user_management/users";
         $params = [
             "email" => null,
             "organization_id" => null,


### PR DESCRIPTION
## Description
Rename organization parameter filter
Use new API path

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
