### PR TITLE
User Management - Update sendMagicAuthCode to use the right url and rename parameter

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -401,18 +401,18 @@ class UserManagement
     /**
      * Creates a one-time Magic Auth code and emails it to the user.
      *
-     * @param string $emailAddress The email address the one-time code will be sent to.
+     * @param string $email The email address the one-time code will be sent to.
      *
      * @throws Exception\WorkOSException
      *
      * @return \WorkOS\Resource\User
      */
-    public function sendMagicAuthCode($emailAddress)
+    public function sendMagicAuthCode($email)
     {
-        $sendCodePath = "users/magic_auth/send";
+        $sendCodePath = "/user_management/magic_auth/send";
 
         $params = [
-            "email_address" => $emailAddress,
+            "email" => $email,
         ];
 
         $response = Client::request(

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -483,7 +483,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     private function testSendMagicAuthCode()
     {
-        $sendCodePath = "users/magic_auth/send";
+        $sendCodePath = "/user_management/magic_auth/send";
 
         $result = $this->createUserResponseFixture();
 


### PR DESCRIPTION
## Description
Update sendMagicAuthCode to use the right url and rename parameter

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
