### PR TITLE
User Management - use new path for password reset flow

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -279,7 +279,7 @@ class UserManagement
      */
     public function sendPasswordResetEmail($email, $passwordResetUrl)
     {
-        $sendPasswordResetEmailPath = "users/send_password_reset_email";
+        $sendPasswordResetEmailPath = "user_management/password_reset/send";
 
         $params = [
             "email" => $email,
@@ -303,7 +303,7 @@ class UserManagement
      */
     public function resetPassword($token, $newPassword)
     {
-        $resetPasswordPath = "users/password_reset";
+        $resetPasswordPath = "user_management/password_reset/confirm";
 
         $params = [
             "token" => $token,

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -352,7 +352,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testSendPasswordResetEmail()
     {
-        $sendPasswordResetEmailPath = "users/send_password_reset_email";
+        $sendPasswordResetEmailPath = "user_management/password_reset/send";
 
         $result = $this->createUserAndTokenResponseFixture();
 
@@ -380,7 +380,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testResetPassword()
     {
-        $resetPasswordPath = "users/password_reset";
+        $resetPasswordPath = "user_management/password_reset/confirm";
 
         $result = $this->userResponseFixture();
 


### PR DESCRIPTION
## Description
User Management - use new path for password reset flow

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
