### PR TITLE
User Management - rename verifyEmailToken and rename path variables

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -25,7 +25,7 @@ class UserManagement
      */
     public function createUser($email, $password, $firstName, $lastName, $emailVerified)
     {
-        $usersPath = "users";
+        $path = "users";
         $params = [
             "email" => $email,
             "password" => $password,
@@ -34,7 +34,7 @@ class UserManagement
             "email_verified" => $emailVerified
         ];
 
-        $response = Client::request(Client::METHOD_POST, $usersPath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $path, null, $params, true);
 
         return Resource\User::constructFromResponse($response);
     }
@@ -50,9 +50,9 @@ class UserManagement
      */
     public function getUser($userId)
     {
-        $usersPath = "users/{$userId}";
+        $path = "users/{$userId}";
 
-        $response = Client::request(Client::METHOD_GET, $usersPath, null, null, true);
+        $response = Client::request(Client::METHOD_GET, $path, null, null, true);
 
         return Resource\User::constructFromResponse($response);
     }
@@ -71,7 +71,7 @@ class UserManagement
      */
     public function updateUser($userId, $firstName = null, $lastName = null, $emailVerified = null)
     {
-        $usersPath = "users/{$userId}";
+        $path = "users/{$userId}";
 
         $params = [
             "first_name" => $firstName,
@@ -79,7 +79,7 @@ class UserManagement
             "email_verified" => $emailVerified
         ];
 
-        $response = Client::request(Client::METHOD_PUT, $usersPath, null, $params, true);
+        $response = Client::request(Client::METHOD_PUT, $path, null, $params, true);
 
         return Resource\User::constructFromResponse($response);
     }
@@ -109,7 +109,7 @@ class UserManagement
         $after = null,
         $order = null
     ) {
-        $usersPath = "user_management/users";
+        $path = "user_management/users";
 
         $params = [
             "email" => $email,
@@ -122,7 +122,7 @@ class UserManagement
 
         $response = Client::request(
             Client::METHOD_GET,
-            $usersPath,
+            $path,
             null,
             $params,
             true
@@ -148,9 +148,9 @@ class UserManagement
      */
     public function deleteUser($userId)
     {
-        $usersPath = "user_management/users/{$userId}";
+        $path = "user_management/users/{$userId}";
 
-        $response = Client::request(Client::METHOD_DELETE, $usersPath, null, null, true);
+        $response = Client::request(Client::METHOD_DELETE, $path, null, null, true);
 
         return $response;
     }
@@ -441,7 +441,7 @@ class UserManagement
      */
     public function authenticateWithPassword($clientId, $email, $password, $ipAddress = null, $userAgent = null)
     {
-        $authenticateWithPasswordPath = "users/authenticate";
+        $path = "users/authenticate";
         $params = [
             "client_id" => $clientId,
             "email" => $email,
@@ -452,7 +452,7 @@ class UserManagement
             "client_secret" => WorkOS::getApiKey()
         ];
 
-        $response = Client::request(Client::METHOD_POST, $authenticateWithPasswordPath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $path, null, $params, true);
 
         return Resource\UserResponse::constructFromResponse($response);
     }
@@ -471,7 +471,7 @@ class UserManagement
      */
     public function authenticateWithCode($clientId, $code, $ipAddress = null, $userAgent = null)
     {
-        $authenticateWithCodePath = "users/authenticate";
+        $path = "users/authenticate";
         $params = [
             "client_id" => $clientId,
             "code" => $code,
@@ -481,7 +481,7 @@ class UserManagement
             "client_secret" => WorkOS::getApiKey()
         ];
 
-        $response = Client::request(Client::METHOD_POST, $authenticateWithCodePath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $path, null, $params, true);
 
         return Resource\UserResponse::constructFromResponse($response);
     }
@@ -502,7 +502,7 @@ class UserManagement
 
     public function authenticateWithMagicAuth($clientId, $code, $userId, $ipAddress = null, $userAgent = null)
     {
-        $authenticateWithMagicAuthPath = "users/authenticate";
+        $path = "users/authenticate";
         $params = [
             "client_id" => $clientId,
             "code" => $code,
@@ -513,7 +513,7 @@ class UserManagement
             "client_secret" => WorkOS::getApiKey()
         ];
 
-        $response = Client::request(Client::METHOD_POST, $authenticateWithMagicAuthPath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $path, null, $params, true);
 
         return Resource\UserResponse::constructFromResponse($response);
     }
@@ -532,7 +532,7 @@ class UserManagement
      */
     public function authenticateWithTotp($clientId, $pendingAuthenticationToken, $authenticationChallengeId, $code)
     {
-        $authenticatePath = "users/authenticate";
+        $path = "users/authenticate";
         $params = [
             "client_id" => $clientId,
             "pending_authentication_token" => $pendingAuthenticationToken,
@@ -542,7 +542,7 @@ class UserManagement
             "client_secret" => WorkOS::getApiKey()
         ];
 
-        $response = Client::request(Client::METHOD_POST, $authenticatePath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $path, null, $params, true);
 
         return Resource\UserResponse::constructFromResponse($response);
     }
@@ -559,13 +559,13 @@ class UserManagement
      */
     public function enrollAuthFactor($userId, $type)
     {
-        $enrollAuthFactorPath = "users/{$userId}/auth/factors";
+        $path = "users/{$userId}/auth/factors";
 
         $params = [
             "type" => $type
         ];
 
-        $response = Client::request(Client::METHOD_POST, $enrollAuthFactorPath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $path, null, $params, true);
 
         return Resource\AuthenticationFactorAndChallengeTotp::constructFromResponse($response);
     }
@@ -581,9 +581,9 @@ class UserManagement
      */
     public function listAuthFactors($userId)
     {
-        $usersPath = "users/{$userId}/auth/factors";
+        $path = "users/{$userId}/auth/factors";
 
-        $response = Client::request(Client::METHOD_GET, $usersPath, null, null, true);
+        $response = Client::request(Client::METHOD_GET, $path, null, null, true);
 
         $authFactors = [];
 
@@ -605,9 +605,9 @@ class UserManagement
      */
     public function sendVerificationEmail($userId)
     {
-        $sendVerificationEmailPath = "user_management/users/{$userId}/email_verification/send";
+        $path = "user_management/users/{$userId}/email_verification/send";
 
-        $response = Client::request(Client::METHOD_POST, $sendVerificationEmailPath, null, null, true);
+        $response = Client::request(Client::METHOD_POST, $path, null, null, true);
 
         return Resource\User::constructFromResponse($response);
     }
@@ -647,14 +647,14 @@ class UserManagement
      */
     public function sendPasswordResetEmail($email, $passwordResetUrl)
     {
-        $sendPasswordResetEmailPath = "user_management/password_reset/send";
+        $path = "user_management/password_reset/send";
 
         $params = [
             "email" => $email,
             "password_reset_url" => $passwordResetUrl
         ];
 
-        $response = Client::request(Client::METHOD_POST, $sendPasswordResetEmailPath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $path, null, $params, true);
 
         return Resource\UserAndToken::constructFromResponse($response);
     }
@@ -671,14 +671,14 @@ class UserManagement
      */
     public function resetPassword($token, $newPassword)
     {
-        $resetPasswordPath = "user_management/password_reset/confirm";
+        $path = "user_management/password_reset/confirm";
 
         $params = [
             "token" => $token,
             "new_password" => $newPassword
         ];
 
-        $response = Client::request(Client::METHOD_POST, $resetPasswordPath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $path, null, $params, true);
 
         return Resource\UserResponse::constructFromResponse($response);
     }
@@ -695,13 +695,13 @@ class UserManagement
      */
     public function updateUserPassword($userId, $password)
     {
-        $usersPath = "users/{$userId}/password";
+        $path = "users/{$userId}/password";
 
         $params = [
             "password" => $password
         ];
 
-        $response = Client::request(Client::METHOD_PUT, $usersPath, null, $params, true);
+        $response = Client::request(Client::METHOD_PUT, $path, null, $params, true);
 
         return Resource\User::constructFromResponse($response);
     }
@@ -717,7 +717,7 @@ class UserManagement
      */
     public function sendMagicAuthCode($email)
     {
-        $sendCodePath = "/user_management/magic_auth/send";
+        $path = "/user_management/magic_auth/send";
 
         $params = [
             "email" => $email,
@@ -725,7 +725,7 @@ class UserManagement
 
         $response = Client::request(
             Client::METHOD_POST,
-            $sendCodePath,
+            $path,
             null,
             $params,
             true

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -622,15 +622,15 @@ class UserManagement
      *
      * @return \WorkOS\Resource\UserResponse
      */
-    public function verifyEmailCode($userId, $code)
+    public function verifyEmail($userId, $code)
     {
-        $verifyEmailCodePath = "user_management/users/{$userId}/email_verification/confirm";
+        $path = "user_management/users/{$userId}/email_verification/confirm";
 
         $params = [
             "code" => $code
         ];
 
-        $response = Client::request(Client::METHOD_POST, $verifyEmailCodePath, null, $params, true);
+        $response = Client::request(Client::METHOD_POST, $path, null, $params, true);
 
         return Resource\UserResponse::constructFromResponse($response);
     }

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -19,12 +19,12 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public function testDeleteUser()
     {
         $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";
-        $usersPath = "user_management/users/{$userId}";
+        $path = "user_management/users/{$userId}";
         $responseCode = 204;
 
         $this->mockRequest(
             Client::METHOD_DELETE,
-            $usersPath,
+            $path,
             null,
             null,
             true,
@@ -41,7 +41,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public function testUpdateUser()
     {
         $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";
-        $usersPath = "users/{$userId}";
+        $path = "users/{$userId}";
 
         $result = $this->createUserResponseFixture();
 
@@ -53,7 +53,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->mockRequest(
             Client::METHOD_PUT,
-            $usersPath,
+            $path,
             null,
             $params,
             true,
@@ -69,7 +69,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public function testUpdateUserPassword()
     {
         $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";
-        $usersPath = "users/{$userId}/password";
+        $path = "users/{$userId}/password";
 
         $result = $this->createUserResponseFixture();
 
@@ -79,7 +79,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->mockRequest(
             Client::METHOD_PUT,
-            $usersPath,
+            $path,
             null,
             $params,
             true,
@@ -94,7 +94,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testAuthenticateWithPassword()
     {
-        $usersPath = "users/authenticate";
+        $path = "users/authenticate";
         WorkOS::setApiKey("sk_test_12345");
         $result = $this->UserResponseFixture();
 
@@ -110,7 +110,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->mockRequest(
             Client::METHOD_POST,
-            $usersPath,
+            $path,
             null,
             $params,
             true,
@@ -125,7 +125,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testAuthenticateWithCode()
     {
-        $usersPath = "users/authenticate";
+        $path = "users/authenticate";
         WorkOS::setApiKey("sk_test_12345");
         $result = $this->UserResponseFixture();
 
@@ -140,7 +140,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->mockRequest(
             Client::METHOD_POST,
-            $usersPath,
+            $path,
             null,
             $params,
             true,
@@ -182,7 +182,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testAuthenticateWithTotp()
     {
-        $usersPath = "users/authenticate";
+        $path = "users/authenticate";
         WorkOS::setApiKey("sk_test_12345");
         $result = $this->UserResponseFixture();
 
@@ -197,7 +197,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->mockRequest(
             Client::METHOD_POST,
-            $usersPath,
+            $path,
             null,
             $params,
             true,
@@ -214,7 +214,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testAuthenticateWithMagicAuth()
     {
-        $usersPath = "users/authenticate";
+        $path = "users/authenticate";
         WorkOS::setApiKey("sk_test_12345");
         $result = $this->UserResponseFixture();
 
@@ -230,7 +230,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->mockRequest(
             Client::METHOD_POST,
-            $usersPath,
+            $path,
             null,
             $params,
             true,
@@ -245,7 +245,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateUser()
     {
-        $usersPath = "users";
+        $path = "users";
 
         $result = $this->createUserResponseFixture();
 
@@ -259,7 +259,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->mockRequest(
             Client::METHOD_POST,
-            $usersPath,
+            $path,
             null,
             $params,
             true,
@@ -275,14 +275,14 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public function testSendVerificationEmail()
     {
         $userId = "user_01E4ZCR3C56J083X43JQXF3JK5";
-        $sendVerificationEmailPath = "user_management/users/{$userId}/email_verification/send";
+        $path = "user_management/users/{$userId}/email_verification/send";
 
         $result = $this->createUserResponseFixture();
 
 
         $this->mockRequest(
             Client::METHOD_POST,
-            $sendVerificationEmailPath,
+            $path,
             null,
             null,
             true,
@@ -296,10 +296,10 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($user, $response->toArray());
     }
 
-    public function testVerifyEmailCode()
+    public function testVerifyEmail()
     {
         $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";
-        $verifyEmailCodePath = "user_management/users/{$userId}/email_verification/confirm";
+        $path = "user_management/users/{$userId}/email_verification/confirm";
 
         $result = $this->UserResponseFixture();
 
@@ -309,7 +309,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->mockRequest(
             Client::METHOD_POST,
-            $verifyEmailCodePath,
+            $path,
             null,
             $params,
             true,
@@ -318,13 +318,13 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $userFixture = $this->userFixture();
 
-        $response = $this->userManagement->verifyEmailCode("user_01H7X1M4TZJN5N4HG4XXMA1234", "01DMEK0J53CVMC32CK5SE0KZ8Q");
+        $response = $this->userManagement->verifyEmail("user_01H7X1M4TZJN5N4HG4XXMA1234", "01DMEK0J53CVMC32CK5SE0KZ8Q");
         $this->assertSame($userFixture, $response->user->toArray());
     }
 
     public function testSendPasswordResetEmail()
     {
-        $sendPasswordResetEmailPath = "user_management/password_reset/send";
+        $path = "user_management/password_reset/send";
 
         $result = $this->createUserAndTokenResponseFixture();
 
@@ -335,7 +335,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->mockRequest(
             Client::METHOD_POST,
-            $sendPasswordResetEmailPath,
+            $path,
             null,
             $params,
             true,
@@ -352,7 +352,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testResetPassword()
     {
-        $resetPasswordPath = "user_management/password_reset/confirm";
+        $path = "user_management/password_reset/confirm";
 
         $result = $this->userResponseFixture();
 
@@ -363,7 +363,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->mockRequest(
             Client::METHOD_POST,
-            $resetPasswordPath,
+            $path,
             null,
             $params,
             true,
@@ -381,13 +381,13 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public function testGetUser()
     {
         $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";
-        $usersPath = "users/{$userId}";
+        $path = "users/{$userId}";
 
         $result = $this->getUserResponseFixture();
 
         $this->mockRequest(
             Client::METHOD_GET,
-            $usersPath,
+            $path,
             null,
             null,
             true,
@@ -403,7 +403,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testListUsers()
     {
-        $usersPath = "user_management/users";
+        $path = "user_management/users";
         $params = [
             "email" => null,
             "organization_id" => null,
@@ -417,7 +417,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->mockRequest(
             Client::METHOD_GET,
-            $usersPath,
+            $path,
             null,
             $params,
             true,
@@ -431,7 +431,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     private function testSendMagicAuthCode()
     {
-        $sendCodePath = "/user_management/magic_auth/send";
+        $path = "/user_management/magic_auth/send";
 
         $result = $this->createUserResponseFixture();
 
@@ -441,7 +441,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->mockRequest(
             Client::METHOD_POST,
-            $sendCodePath,
+            $path,
             null,
             $params,
             true,
@@ -457,13 +457,13 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public function testListAuthFactors()
     {
         $userId = "user_01H96FETWYSJMJEGF0Q3ZB272F";
-        $usersPath = "users/{$userId}/auth/factors";
+        $path = "users/{$userId}/auth/factors";
 
         $result = $this->listAuthFactorResponseFixture();
 
         $this->mockRequest(
             Client::METHOD_GET,
-            $usersPath,
+            $path,
             null,
             null,
             true,


### PR DESCRIPTION
## Description
User Management - rename verifyEmailToken and rename path variables

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
