### PR TITLE
User Management - Validate provider value in getAuthorizationUrl

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -10,6 +10,10 @@ class UserManagement
     public const DEFAULT_PAGE_SIZE = 10;
     public const DEFAULT_TOKEN_EXPIRATION = 1440;
 
+    public const AUTHORIZATION_PROVIDER_AUTHKIT = "authkit";
+    public const AUTHORIZATION_PROVIDER_GOOGLE_OAUTH = "GoogleOAuth";
+    public const AUTHORIZATION_PROVIDER_MICROSOFT_OAUTH = "MicrosoftOAuth";
+
     /**
      * Create User.
      *
@@ -455,6 +459,17 @@ class UserManagement
 
         if (!isset($provider) && !isset($connectionId) && !isset($organizationId)) {
             $msg = "Either \$provider, \$connectionId, or \$organizationId is required";
+            throw new Exception\UnexpectedValueException($msg);
+        }
+
+        $supportedProviders = [
+            self::AUTHORIZATION_PROVIDER_AUTHKIT,
+            self::AUTHORIZATION_PROVIDER_GOOGLE_OAUTH,
+            self::AUTHORIZATION_PROVIDER_MICROSOFT_OAUTH
+        ];
+
+        if (isset($provider) && !\in_array($provider, $supportedProviders)) {
+            $msg = "Only " . implode("','", $supportedProviders) . " providers are supported";
             throw new Exception\UnexpectedValueException($msg);
         }
 

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -92,6 +92,25 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($user, $response->toArray());
     }
 
+    public function testAuthorizationURLInvalidInputs()
+    {
+
+        $this->expectException(Exception\UnexpectedValueException::class);
+        $authorizationUrl = $this->userManagement->getAuthorizationUrl(
+            "https://apage.com",
+            null,
+            "randomProvider",
+        );
+
+        $this->expectException(Exception\UnexpectedValueException::class);
+        $authorizationUrl = $this->userManagement->getAuthorizationUrl(
+            "https://apage.com",
+            null,
+            null,
+            null,
+        );
+    }
+
     public static function authorizationUrlTestDataProvider()
     {
         return [


### PR DESCRIPTION
## Description
User Management - Validate provider value in getAuthorizationUrl

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
