### PR TITLE
Update return type of ResetPassword and sendPasswordResetEmail

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -742,7 +742,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\UserAndToken
+     * @return \WorkOS\Resource\Response
      */
     public function sendPasswordResetEmail($email, $passwordResetUrl)
     {
@@ -755,7 +755,7 @@ class UserManagement
 
         $response = Client::request(Client::METHOD_POST, $path, null, $params, true);
 
-        return Resource\UserAndToken::constructFromResponse($response);
+        return $response;
     }
 
     /**
@@ -789,7 +789,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\User
+     * @return \WorkOS\Resource\Response
      */
     public function sendMagicAuthCode($email)
     {
@@ -807,6 +807,6 @@ class UserManagement
             true
         );
 
-        return Resource\User::constructFromResponse($response);
+        return $response;
     }
 }

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -20,7 +20,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     {
         $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";
         $path = "user_management/users/{$userId}";
-        $responseCode = 204;
+        $responseCode = 200;
 
         $this->mockRequest(
             Client::METHOD_DELETE,
@@ -34,7 +34,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         );
 
         $response = $this->userManagement->deleteUser($userId);
-        $this->assertSame(204, $responseCode);
+        $this->assertSame(200, $responseCode);
         $this->assertSame($response, []);
     }
 
@@ -395,7 +395,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     {
         $path = "user_management/password_reset/send";
 
-        $responseCode = 204;
+        $responseCode = 200;
         $params = [
             "email" => "test@test.com",
             "password_reset_url" => "https://your-app.com/reset-password"
@@ -413,7 +413,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         );
 
         $response = $this->userManagement->sendPasswordResetEmail("test@test.com", "https://your-app.com/reset-password");
-        $this->assertSame(204, $responseCode);
+        $this->assertSame(200, $responseCode);
         $this->assertSame($response, []);
 
     }
@@ -505,7 +505,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "email" => "test@test.com"
         ];
 
-        $responseCode = 204;
+        $responseCode = 200;
 
         $this->mockRequest(
             Client::METHOD_POST,
@@ -522,7 +522,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->userManagement->sendMagicAuthCode("test@test.com");
 
-        $this->assertSame(204, $responseCode);
+        $this->assertSame(200, $responseCode);
         $this->assertSame($response, []);
     }
 
@@ -644,8 +644,6 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             null,
             null,
             true,
-            null,
-            204
         );
 
         $response = $this->userManagement->deleteOrganizationMembership($organizationMembershipId);

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -395,8 +395,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     {
         $path = "user_management/password_reset/send";
 
-        $result = $this->createUserAndTokenResponseFixture();
-
+        $responseCode = 204;
         $params = [
             "email" => "test@test.com",
             "password_reset_url" => "https://your-app.com/reset-password"
@@ -408,15 +407,15 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             null,
             $params,
             true,
-            $result
+            null,
+            null,
+            $responseCode
         );
 
-
-        $userFixture = $this->userFixture();
-
         $response = $this->userManagement->sendPasswordResetEmail("test@test.com", "https://your-app.com/reset-password");
-        $this->assertSame("01DMEK0J53CVMC32CK5SE0KZ8Q", $response->token);
-        $this->assertSame($userFixture, $response->user->toArray());
+        $this->assertSame(204, $responseCode);
+        $this->assertSame($response, []);
+
     }
 
     public function testResetPassword()
@@ -502,11 +501,11 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     {
         $path = "/user_management/magic_auth/send";
 
-        $result = $this->createUserResponseFixture();
-
         $params = [
             "email" => "test@test.com"
         ];
+
+        $responseCode = 204;
 
         $this->mockRequest(
             Client::METHOD_POST,
@@ -514,13 +513,17 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             null,
             $params,
             true,
-            $result
+            null,
+            null,
+            $responseCode
         );
 
         $user = $this->userFixture();
 
         $response = $this->userManagement->sendMagicAuthCode("test@test.com");
-        $this->assertSame($user, $response->toArray());
+
+        $this->assertSame(204, $responseCode);
+        $this->assertSame($response, []);
     }
 
     public function testListAuthFactors()


### PR DESCRIPTION
## Description
Update return type of ResetPassword and sendPasswordResetEmail

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
