### PR TITLE
User Management - Add totp Issuer and User to enroll api

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -734,6 +734,8 @@ class UserManagement
      *
      * @param string $userId The unique ID of the user.
      * @param string $type The type of MFA factor used to authenticate.
+     * @param string|null $totpIssuer Your application or company name, this helps users distinguish between factors in authenticator apps.
+     * @param string|null $totpUser Used as the account name in authenticator apps.
      *
      * @throws Exception\WorkOSException
      *

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -739,12 +739,14 @@ class UserManagement
      *
      * @return \WorkOS\Resource\UserResponse
      */
-    public function enrollAuthFactor($userId, $type)
+    public function enrollAuthFactor($userId, $type, $totpIssuer, $totpUser)
     {
         $path = "user_management/users/{$userId}/auth_factors";
 
         $params = [
-            "type" => $type
+            "type" => $type,
+            "totp_user" => $totpUser,
+            "totp_issuer" => $totpIssuer
         ];
 
         $response = Client::request(Client::METHOD_POST, $path, null, $params, true);

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -298,7 +298,9 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $userId = "user_123456";
         $path = "user_management/users/{$userId}/auth_factors";
         $params = [
-            "type" => "totp"
+            "type" => "totp",
+            "totp_user" => "totpUser",
+            "totp_issuer" => "totpIssuer"
         ];
 
         $result = $this->enrollAuthFactorResponseFixture();
@@ -312,7 +314,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             $result
         );
 
-        $enrollFactorTotp = $this->userManagement->enrollAuthFactor($userId, "totp");
+        $enrollFactorTotp = $this->userManagement->enrollAuthFactor($userId, "totp", "totpIssuer", "totpUser");
         $enrollUserAuthFactorFixture = $this->enrollAuthFactorFixture();
         $enrollUserAuthChallengeFixture = $this->enrollAuthChallengeFixture();
 


### PR DESCRIPTION
## Description
Add totp Issuer and User to enroll api

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
