### PR TITLE
Add status to organization membership

### DIFF
--- a/lib/Resource/OrganizationMembership.php
+++ b/lib/Resource/OrganizationMembership.php
@@ -15,6 +15,7 @@ class OrganizationMembership extends BaseWorkOSResource
         "id",
         "userId",
         "organizationId",
+        "status",
         "createdAt",
         "updatedAt"
     ];
@@ -24,6 +25,7 @@ class OrganizationMembership extends BaseWorkOSResource
         "id" => "id",
         "user_id" => "userId",
         "organization_id" => "organizationId",
+        "status" => "status",
         "created_at" => "createdAt",
         "updated_at" => "updatedAt"
     ];

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -940,6 +940,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "id" => "om_01E4ZCR3C56J083X43JQXF3JK5",
             "userId" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
             "organizationId" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
+            "status" => "active",
             "createdAt" => "2021-06-25T19:07:33.155Z",
             "updatedAt" => "2021-06-25T19:07:33.155Z",
         ];

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -906,6 +906,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "id" => "om_01E4ZCR3C56J083X43JQXF3JK5",
             "user_id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
             "organization_id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
+            "status" => "active",
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z",
         ]);
@@ -921,6 +922,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
                         "id" => "om_01E4ZCR3C56J083X43JQXF3JK5",
                         "user_id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
                         "organization_id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
+                        "status" => "active",
                         "created_at" => "2021-06-25T19:07:33.155Z",
                         "updated_at" => "2021-06-25T19:07:33.155Z",
                     ]


### PR DESCRIPTION
## Description

Adds new `status` attribute to organization membership.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/25404
