### PR TITLE
Remove "domain" param from list directories query

### DIFF
--- a/lib/DirectorySync.php
+++ b/lib/DirectorySync.php
@@ -14,7 +14,6 @@ class DirectorySync
     /**
      * List Directories.
      *
-     * @param null|string $domain Domain of a Directory
      * @param null|string $search Searchable text for a Directory
      * @param int $limit Maximum number of records to return
      * @param null|string $before Directory ID to look before
@@ -30,7 +29,6 @@ class DirectorySync
      *      array \WorkOS\Resource\Directory instances
      */
     public function listDirectories(
-        $domain = null,
         $search = null,
         $limit = self::DEFAULT_PAGE_SIZE,
         $before = null,
@@ -43,7 +41,6 @@ class DirectorySync
             "limit" => $limit,
             "before" => $before,
             "after" => $after,
-            "domain" => $domain,
             "search" => $search,
             "organization_id" => $organizationId,
             "order" => $order

--- a/tests/WorkOS/DirectorySyncTest.php
+++ b/tests/WorkOS/DirectorySyncTest.php
@@ -23,7 +23,6 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
             "limit" => DirectorySync::DEFAULT_PAGE_SIZE,
             "before" => null,
             "after" => null,
-            "domain" => null,
             "search" => null,
             "organization_id" => null,
             "order" => null


### PR DESCRIPTION
## Description
We no longer support querying directories by domain, so removing the option from the method doc.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
