### PR TITLE
Add 'password_hash' and 'password_hash_type' to User creation

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -23,7 +23,7 @@ class UserManagement
      * @param string|null $lastName The last name of the user.
      * @param boolean|null $emailVerified A boolean declaring if the user's email has been verified.
      * @param string|null $passwordHash The hashed password to set for the user.
-     * @param string|null $passwordHashType The algorithm originally used to hash the password. Valid values are bcrypt.
+     * @param string|null $passwordHashType The algorithm originally used to hash the password. Valid values are `bcrypt`, `ssha`, and `firebase-scrypt`.
      *
      * @throws Exception\WorkOSException
      *
@@ -74,7 +74,7 @@ class UserManagement
      * @param boolean|null $emailVerified A boolean declaring if the user's email has been verified.
      * @param string|null $password The password to set for the user.
      * @param string|null $passwordHash The hashed password to set for the user.
-     * @param string|null $passwordHashType The algorithm originally used to hash the password. Valid values are bcrypt.
+     * @param string|null $passwordHashType The algorithm originally used to hash the password. Valid values are `bcrypt`, `ssha`, and `firebase-scrypt`.
      *
      * @throws Exception\WorkOSException
      *

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -22,12 +22,14 @@ class UserManagement
      * @param string|null $firstName The first name of the user.
      * @param string|null $lastName The last name of the user.
      * @param boolean|null $emailVerified A boolean declaring if the user's email has been verified.
+     * @param string|null $passwordHash The hashed password to set for the user.
+     * @param string|null $passwordHashType The algorithm originally used to hash the password. Valid values are bcrypt.
      *
      * @throws Exception\WorkOSException
      *
      * @return \WorkOS\Resource\User
      */
-    public function createUser($email, $password, $firstName, $lastName, $emailVerified)
+    public function createUser($email, $password, $firstName, $lastName, $emailVerified, $passwordHash = null, $passwordHashType = null)
     {
         $path = "user_management/users";
         $params = [
@@ -35,7 +37,9 @@ class UserManagement
             "password" => $password,
             "first_name" => $firstName,
             "last_name" => $lastName,
-            "email_verified" => $emailVerified
+            "email_verified" => $emailVerified,
+            "password_hash" => $passwordHash,
+            "password_hash_type" => $passwordHashType,
         ];
 
         $response = Client::request(Client::METHOD_POST, $path, null, $params, true);

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS;
 final class Version
 {
     public const SDK_IDENTIFIER = "WorkOS PHP";
-    public const SDK_VERSION = '4.3.1';
+    public const SDK_VERSION = '4.3.0';
 }

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS;
 final class Version
 {
     public const SDK_IDENTIFIER = "WorkOS PHP";
-    public const SDK_VERSION = '4.3.0';
+    public const SDK_VERSION = '4.3.1';
 }

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -432,7 +432,9 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "password" => "x^T!V23UN1@V",
             "first_name" => "Damien",
             "last_name" => "Alabaster",
-            "email_verified" => true
+            "email_verified" => true,
+            "password_hash" => null,
+            "password_hash_type" => null,
         ];
 
         $this->mockRequest(


### PR DESCRIPTION
## Description
This PR ensures that the User create process allows for the `password_hash` and `password_hash_type` fields, in addition to the existing `password` field, similar to the Update process.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/26060
