### PR TITLE
Add `domain_data` to Organization API and deprecate `domains`

### DIFF
--- a/lib/Organizations.php
+++ b/lib/Organizations.php
@@ -65,8 +65,8 @@ class Organizations
      * Create Organization.
      *
      * @param string $name The name of the Organization.
-     * @param array $domains [Deprecated] The domains of the Organization. Use domain_data instead.
-     * @param array $domain_data The domains of the Organization.
+     * @param null|array $domains [Deprecated] The domains of the Organization. Use domain_data instead.
+     * @param null|array $domain_data The domains of the Organization.
      * @param null|boolean $allowProfilesOutsideOrganization Whether Connections within the Organization allow profiles
      *      that are outside of the Organization's configured User Email Domains.
      * @param null|string $idempotencyKey is a unique string that identifies a distinct organization
@@ -95,9 +95,9 @@ class Organizations
      * Update Organization.
      *
      * @param string $organization An Organization identifier.
-     * @param array $domains [Deprecated] The domains of the Organization. Use domain_data instead.
-     * @param array $domain_data The domains of the Organization.
-     * @param string $name The name of the Organization.
+     * @param null|array $domains [Deprecated] The domains of the Organization. Use domain_data instead.
+     * @param null|array $domain_data The domains of the Organization.
+     * @param null|string $name The name of the Organization.
      * @param null|boolean $allowProfilesOutsideOrganization Whether Connections within the Organization allow profiles
      *      that are outside of the Organization's configured User Email Domains.
      *

--- a/lib/Organizations.php
+++ b/lib/Organizations.php
@@ -65,7 +65,8 @@ class Organizations
      * Create Organization.
      *
      * @param string $name The name of the Organization.
-     * @param array $domains The domains of the Organization.
+     * @param array $domains [Deprecated] The domains of the Organization. Use domain_data instead.
+     * @param array $domain_data The domains of the Organization.
      * @param null|boolean $allowProfilesOutsideOrganization Whether Connections within the Organization allow profiles
      *      that are outside of the Organization's configured User Email Domains.
      * @param null|string $idempotencyKey is a unique string that identifies a distinct organization
@@ -74,13 +75,14 @@ class Organizations
      *
      * @return \WorkOS\Resource\Organization
      */
-    public function createOrganization($name, $domains, $allowProfilesOutsideOrganization = null, $idempotencyKey = null)
+    public function createOrganization($name, $domains = null, $allowProfilesOutsideOrganization = null, $idempotencyKey = null, $domain_data = null)
     {
         $idempotencyKey ? $headers = array("Idempotency-Key: $idempotencyKey") : $headers = null;
         $organizationsPath = "organizations";
         $params = [
             "name" => $name,
             "domains" => $domains,
+            "domain_data" => $domain_data,
             "allow_profiles_outside_organization" => $allowProfilesOutsideOrganization
         ];
 
@@ -93,19 +95,20 @@ class Organizations
      * Update Organization.
      *
      * @param string $organization An Organization identifier.
-     * @param array $domains The domains of the Organization.
+     * @param array $domains [Deprecated] The domains of the Organization. Use domain_data instead.
+     * @param array $domain_data The domains of the Organization.
      * @param string $name The name of the Organization.
      * @param null|boolean $allowProfilesOutsideOrganization Whether Connections within the Organization allow profiles
      *      that are outside of the Organization's configured User Email Domains.
      *
      * @throws Exception\WorkOSException
      */
-    public function updateOrganization($organization, $domains, $name, $allowProfilesOutsideOrganization = null)
+    public function updateOrganization($organization, $domains = null, $name = null, $allowProfilesOutsideOrganization = null, $domain_data = null)
     {
         $organizationsPath = "organizations/{$organization}";
         $params = [
-          "organization" => $organization,
           "domains" => $domains,
+          "domain_data" => $domain_data,
           "name" => $name,
           "allow_profiles_outside_organization" => $allowProfilesOutsideOrganization
         ];

--- a/tests/WorkOS/OrganizationsTest.php
+++ b/tests/WorkOS/OrganizationsTest.php
@@ -16,7 +16,7 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
         $this->organizations = new Organizations();
     }
 
-    public function testCreateOrganization()
+    public function testCreateOrganizationWithDomains()
     {
         $organizationsPath = "organizations";
 
@@ -25,6 +25,7 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
         $params = [
             "name" => "Organization Name",
             "domains" => array("example.com"),
+            "domain_data" => null,
             "allow_profiles_outside_organization" => null
         ];
 
@@ -43,6 +44,74 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($organization, $response->toArray());
     }
 
+    public function testCreateOrganizationWithDomainData()
+    {
+        $organizationsPath = "organizations";
+
+        $result = $this->createOrganizationResponseFixture();
+
+        $params = [
+            "name" => "Organization Name",
+            "domains" => null,
+            "domain_data" => array([
+                "domain" => "example.com",
+                "state" => "verified",
+            ]),
+            "allow_profiles_outside_organization" => null
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $organizationsPath,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $organization = $this->organizationFixture();
+
+        $response = $this->organizations->createOrganization(
+            "Organization Name",
+            domain_data: array(["domain" => "example.com", "state" => "verified"]),
+        );
+        $this->assertSame($organization, $response->toArray());
+    }
+
+    public function testUpdateOrganizationWithDomainData()
+    {
+        $organizationsPath = "organizations/org_01EHQMYV6MBK39QC5PZXHY59C3";
+
+        $result = $this->createOrganizationResponseFixture();
+
+        $params = [
+            "domains" => null,
+            "domain_data" => array([
+                "domain" => "example.com",
+                "state" => "verified",
+            ]),
+            "name" => null,
+            "allow_profiles_outside_organization" => null,
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_PUT,
+            $organizationsPath,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $organization = $this->organizationFixture();
+
+        $response = $this->organizations->updateOrganization(
+            "org_01EHQMYV6MBK39QC5PZXHY59C3",
+            domain_data: array(["domain" => "example.com", "state" => "verified"]),
+        );
+        $this->assertSame($organization, $response->toArray());
+    }
+
     public function testCreateOrganizationSendsIdempotencyKey()
     {
         $organizationsPath = "organizations";
@@ -52,6 +121,7 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
         $params = [
             "name" => "Organization Name",
             "domains" => array("example.com"),
+            "domain_data" => null,
             "allow_profiles_outside_organization" => null
         ];
 


### PR DESCRIPTION
## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
