### PR TITLE
Add API changes for invitations and Magic Auth

### DIFF
--- a/lib/Resource/Invitation.php
+++ b/lib/Resource/Invitation.php
@@ -19,6 +19,7 @@ class Invitation extends BaseWorkOSResource
         "revokedAt",
         "expiresAt",
         "token",
+        "acceptInvitationUrl",
         "organizationId",
         "createdAt",
         "updatedAt"
@@ -33,6 +34,7 @@ class Invitation extends BaseWorkOSResource
         "revoked_at" => "revokedAt",
         "expires_at" => "expiresAt",
         "token" => "token",
+        "accept_invitation_url" => "acceptInvitationUrl",
         "organization_id" => "organizationId",
         "created_at" => "createdAt",
         "updated_at" => "updatedAt"

--- a/lib/Resource/MagicAuth.php
+++ b/lib/Resource/MagicAuth.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class MagicAuth.
+ */
+
+class MagicAuth extends BaseWorkOSResource
+{
+    public const RESOURCE_TYPE = "magic_auth";
+
+    public const RESOURCE_ATTRIBUTES = [
+        "object",
+        "id",
+        "userId",
+        "email",
+        "expiresAt",
+        "code",
+        "createdAt",
+        "updatedAt"
+    ];
+
+    public const RESPONSE_TO_RESOURCE_KEY = [
+        "object" => "object",
+        "id" => "id",
+        "user_id" => "userId",
+        "email" => "email",
+        "expires_at" => "expiresAt",
+        "code" => "code",
+        "created_at" => "createdAt",
+        "updated_at" => "updatedAt"
+    ];
+}

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -884,6 +884,62 @@ class UserManagement
 
         return Resource\UserResponse::constructFromResponse($response);
     }
+    
+    /**
+     * Get a Magic Auth object
+     *
+     * @param string $magicAuthId ID of the Magic Auth object
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\MagicAuth
+     */
+    public function getMagicAuth($magicAuthId)
+    {
+        $path = "/user_management/magic_auth/{$magicAuthId}";
+
+        $response = Client::request(
+            Client::METHOD_GET,
+            $path,
+            null,
+            null,
+            true
+        );
+
+        return Resource\MagicAuth::constructFromResponse($response);
+    }
+    
+    /**
+     * Creates a Magic Auth code
+     *
+     * @param string $email The email address of the user
+     * @param string|null $invitationToken The token of an Invitation, if required.
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\MagicAuth
+     */
+    public function createMagicAuth(
+        $email,
+        $invitationToken = null,
+    ) {
+        $path = "/user_management/magic_auth";
+
+        $params = [
+            "email" => $email,
+            "invitation_token" => $invitationToken
+        ];
+
+        $response = Client::request(
+            Client::METHOD_POST,
+            $path,
+            null,
+            $params,
+            true
+        );
+
+        return Resource\MagicAuth::constructFromResponse($response);
+    }
 
     /**
      * Creates a one-time Magic Auth code and emails it to the user.
@@ -901,6 +957,10 @@ class UserManagement
         $params = [
             "email" => $email,
         ];
+        
+        $msg = "'sendMagicAuthCode' is deprecated. Please use 'createMagicAuth' instead. This method will be removed in a future major version.";
+
+        error_log($msg);
 
         $response = Client::request(
             Client::METHOD_POST,

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -884,7 +884,7 @@ class UserManagement
 
         return Resource\UserResponse::constructFromResponse($response);
     }
-    
+
     /**
      * Get a Magic Auth object
      *
@@ -908,7 +908,7 @@ class UserManagement
 
         return Resource\MagicAuth::constructFromResponse($response);
     }
-    
+
     /**
      * Creates a Magic Auth code
      *
@@ -957,7 +957,7 @@ class UserManagement
         $params = [
             "email" => $email,
         ];
-        
+
         $msg = "'sendMagicAuthCode' is deprecated. Please use 'createMagicAuth' instead. This method will be removed in a future major version.";
 
         error_log($msg);

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -617,6 +617,58 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         list($before, $after, $users) = $this->userManagement->listUsers();
         $this->assertSame($user, $users[0]->toArray());
     }
+    
+    public function testGetMagicAuth()
+    {
+        $magicAuthId = "magic_auth_01E4ZCR3C56J083X43JQXF3JK5";
+        $path = "/user_management/magic_auth/{$magicAuthId}";
+
+        $result = $this->magicAuthResponseFixture();
+
+        $this->mockRequest(
+            Client::METHOD_GET,
+            $path,
+            null,
+            null,
+            true,
+            $result
+        );
+
+        $response = $this->userManagement->getMagicAuth($magicAuthId);
+
+        $expected = $this->magicAuthFixture();
+
+        $this->assertSame($response->toArray(), $expected);
+    }
+    
+    public function testCreateMagicAuth()
+    {
+        $path = "/user_management/magic_auth";
+
+        $result = $this->magicAuthResponseFixture();
+
+        $params = [
+            "email" => "someemail@test.com",
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $path,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $response = $this->userManagement->createMagicAuth(
+            "someemail@test.com",
+        );
+
+        $expected = $this->magicAuthFixture();
+
+        $this->assertSame($response->toArray(), $expected);
+
+    }
 
     private function testSendMagicAuthCode()
     {
@@ -898,6 +950,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "revoked_at" => "2021-07-01T19:07:33.155Z",
             "expires_at" => "2021-07-01T19:07:33.155Z",
             "token" => "Z1uX3RbwcIl5fIGJJJCXXisdI",
+            "accept_invitation_url" => "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
             "organization_id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
             "created_at" => "2021-07-01T19:07:33.155Z",
             "updated_at" => "2021-07-01T19:07:33.155Z",
@@ -915,6 +968,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "revokedAt" => "2021-07-01T19:07:33.155Z",
             "expiresAt" => "2021-07-01T19:07:33.155Z",
             "token" => "Z1uX3RbwcIl5fIGJJJCXXisdI",
+            "acceptInvitationUrl" => "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
             "organizationId" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
             "createdAt" => "2021-07-01T19:07:33.155Z",
             "updatedAt" => "2021-07-01T19:07:33.155Z",
@@ -935,6 +989,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
                         "revoked_at" => "2021-07-01T19:07:33.155Z",
                         "expires_at" => "2021-07-01T19:07:33.155Z",
                         "token" => "Z1uX3RbwcIl5fIGJJJCXXisdI",
+                        "accept_invitation_url" => "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
                         "organization_id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
                         "created_at" => "2021-07-01T19:07:33.155Z",
                         "updated_at" => "2021-07-01T19:07:33.155Z",
@@ -1116,6 +1171,34 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z"
         ]);
+    }
+    
+    private function magicAuthResponseFixture()
+    {
+        return json_encode([
+            "object" => "magic_auth",
+            "id" => "magic_auth_01E4ZCR3C56J083X43JQXF3JK5",
+            "user_id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
+            "email" => "someemail@test.com",
+            "expires_at" => "2021-07-01T19:07:33.155Z",
+            "code" => "123456",
+            "created_at" => "2021-07-01T19:07:33.155Z",
+            "updated_at" => "2021-07-01T19:07:33.155Z",
+        ]);
+    }
+
+    private function magicAuthFixture()
+    {
+        return [
+            "object" => "magic_auth",
+            "id" => "magic_auth_01E4ZCR3C56J083X43JQXF3JK5",
+            "userId" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
+            "email" => "someemail@test.com",
+            "expiresAt" => "2021-07-01T19:07:33.155Z",
+            "code" => "123456",
+            "createdAt" => "2021-07-01T19:07:33.155Z",
+            "updatedAt" => "2021-07-01T19:07:33.155Z",
+        ];
     }
 
     private function sendMagicAuthCodeResponseFixture()

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -536,7 +536,6 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $response = $this->userManagement->sendPasswordResetEmail("test@test.com", "https://your-app.com/reset-password");
         $this->assertSame(200, $responseCode);
         $this->assertSame($response, []);
-
     }
 
     public function testResetPassword()
@@ -617,7 +616,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         list($before, $after, $users) = $this->userManagement->listUsers();
         $this->assertSame($user, $users[0]->toArray());
     }
-    
+
     public function testGetMagicAuth()
     {
         $magicAuthId = "magic_auth_01E4ZCR3C56J083X43JQXF3JK5";
@@ -640,7 +639,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame($response->toArray(), $expected);
     }
-    
+
     public function testCreateMagicAuth()
     {
         $path = "/user_management/magic_auth";
@@ -649,6 +648,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $params = [
             "email" => "someemail@test.com",
+            "invitation_token" => null
         ];
 
         $this->mockRequest(
@@ -667,7 +667,6 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $expected = $this->magicAuthFixture();
 
         $this->assertSame($response->toArray(), $expected);
-
     }
 
     private function testSendMagicAuthCode()
@@ -858,7 +857,6 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $expected = $this->invitationFixture();
 
         $this->assertSame($response->toArray(), $expected);
-
     }
 
     public function testGetInvitation()
@@ -1172,7 +1170,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "updated_at" => "2021-06-25T19:07:33.155Z"
         ]);
     }
-    
+
     private function magicAuthResponseFixture()
     {
         return json_encode([


### PR DESCRIPTION
## Description

Adds events and API changes to support sending your own emails for invitations and Magic Auth.

- Adds `acceptInvitationUrl` to invitation object returned by API
- Adds new endpoints for the Magic Auth API: `getMagicAuth` and `createMagicAuth`
- Deprecates current `sendMagicAuthCode` method in favor of `createMagicAuth`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/26691