### PR TITLE
v4.6.0

### DIFF
--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS;
 final class Version
 {
     public const SDK_IDENTIFIER = "WorkOS PHP";
-    public const SDK_VERSION = '4.5.0';
+    public const SDK_VERSION = '4.6.0';
 }


### PR DESCRIPTION
## Description
Adds API changes to support sending your own emails for invitations and Magic Auth.

- Adds `acceptInvitationUrl` to invitation object returned by API
- Adds new endpoints for the Magic Auth API: `getMagicAuth` and `createMagicAuth`
- Deprecates current `sendMagicAuthCode` method in favor of `createMagicAuth`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
