### PR TITLE
Properly check if a value exists within a BaseWorkOSResource

### DIFF
--- a/lib/Resource/BaseWorkOSResource.php
+++ b/lib/Resource/BaseWorkOSResource.php
@@ -80,7 +80,7 @@ class BaseWorkOSResource
             return $this->values[$key];
         }
 
-        if ($this->raw[$key]) {
+        if (isset($this->raw[$key])) {
             return $this->raw[$key];
         }
 


### PR DESCRIPTION
This PR makes use of the `isset` function (see https://www.php.net/manual/en/function.isset.php) in order to check if a value exists within a Work OS resource.

This is the correct way to determine if a value exists within an array (currently, the native `ErrorException` error is raised when one tries to access a value that doesn't exist).
