### PR TITLE
Add organization membership deactivate and reactivate API methods

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -259,6 +259,7 @@ class UserManagement
      *
      * @param string|null $userId User ID
      * @param string|null $organizationId Organization ID
+     * @param array|null $statuses Organization Membership statuses to filter
      * @param int $limit Maximum number of records to return
      * @param string|null $before Organization Membership ID to look before
      * @param string|null $after Organization Membership ID to look after
@@ -274,6 +275,7 @@ class UserManagement
     public function listOrganizationMemberships(
         $userId,
         $organizationId,
+        $statuses = null,
         $limit = self::DEFAULT_PAGE_SIZE,
         $before = null,
         $after = null,
@@ -281,9 +283,19 @@ class UserManagement
     ) {
         $path = "user_management/organization_memberships";
 
+        if (isset($statuses)) {
+            if (!is_array($statuses)) {
+                $msg = "Invalid argument: statuses must be an array or null.";
+                throw new Exception\UnexpectedValueException($msg);
+            }
+
+            $statuses = join(",", $statuses);
+        }
+
         $params = [
             "organization_id" => $organizationId,
             "user_id" => $userId,
+            "statuses" => $statuses,
             "limit" => $limit,
             "before" => $before,
             "after" => $after,
@@ -307,6 +319,54 @@ class UserManagement
         list($before, $after) = Util\Request::parsePaginationArgs($response);
 
         return [$before, $after, $organizationMemberships];
+    }
+
+    /**
+     * Deactivate an Organization Membership.
+     *
+     * @param string $organizationMembershipId Organization Membership ID
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\Response
+     */
+    public function deactivateOrganizationMembership($organizationMembershipId)
+    {
+        $path = "user_management/organization_memberships/{$organizationMembershipId}/deactivate";
+
+        $response = Client::request(
+            Client::METHOD_POST,
+            $path,
+            null,
+            null,
+            true
+        );
+
+        return Resource\OrganizationMembership::constructFromResponse($response);
+    }
+
+    /**
+     * Reactivate an Organization Membership.
+     *
+     * @param string $organizationMembershipId Organization Membership ID
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\Response
+     */
+    public function reactivateOrganizationMembership($organizationMembershipId)
+    {
+        $path = "user_management/organization_memberships/{$organizationMembershipId}/reactivate";
+
+        $response = Client::request(
+            Client::METHOD_POST,
+            $path,
+            null,
+            null,
+            true
+        );
+
+        return Resource\OrganizationMembership::constructFromResponse($response);
     }
 
     /**

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -335,7 +335,7 @@ class UserManagement
         $path = "user_management/organization_memberships/{$organizationMembershipId}/deactivate";
 
         $response = Client::request(
-            Client::METHOD_POST,
+            Client::METHOD_PUT,
             $path,
             null,
             null,
@@ -359,7 +359,7 @@ class UserManagement
         $path = "user_management/organization_memberships/{$organizationMembershipId}/reactivate";
 
         $response = Client::request(
-            Client::METHOD_POST,
+            Client::METHOD_PUT,
             $path,
             null,
             null,

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -781,6 +781,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $params = [
             "organization_id" => $orgId,
             "user_id" => $userId,
+            "statuses" => null,
             "limit" => 10,
             "before" => null,
             "after" => null,
@@ -803,6 +804,76 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($organizationMembership, $organizationMemberships[0]->toArray());
     }
 
+    public function testListOrganizationMembershipsWithStatuses()
+    {
+        $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";
+        $orgId = "org_01EHQMYV6MBK39QC5PZXHY59C3";
+        $statuses = array("active", "inactive");
+        $path = "user_management/organization_memberships";
+
+        $result = $this->organizationMembershipListResponseFixture();
+
+        $params = [
+            "organization_id" => $orgId,
+            "user_id" => $userId,
+            "statuses" => "active,inactive",
+            "limit" => 10,
+            "before" => null,
+            "after" => null,
+            "order" => null,
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_GET,
+            $path,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $organizationMembership = $this->organizationMembershipFixture();
+
+        list($before, $after, $organizationMemberships) = $this->userManagement->listOrganizationMemberships($userId, $orgId, $statuses);
+
+        $this->assertSame($organizationMembership, $organizationMemberships[0]->toArray());
+    }
+
+    public function testListOrganizationMembershipsWithStatus()
+    {
+        $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";
+        $orgId = "org_01EHQMYV6MBK39QC5PZXHY59C3";
+        $statuses = array("inactive");
+        $path = "user_management/organization_memberships";
+
+        $result = $this->organizationMembershipListResponseFixture();
+
+        $params = [
+            "organization_id" => $orgId,
+            "user_id" => $userId,
+            "statuses" => "inactive",
+            "limit" => 10,
+            "before" => null,
+            "after" => null,
+            "order" => null,
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_GET,
+            $path,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $organizationMembership = $this->organizationMembershipFixture();
+
+        list($before, $after, $organizationMemberships) = $this->userManagement->listOrganizationMemberships($userId, $orgId, $statuses);
+
+        $this->assertSame($organizationMembership, $organizationMemberships[0]->toArray());
+    }
+
     public function testDeleteOrganizationMembership()
     {
         $organizationMembershipId = "om_01E4ZCR3C56J083X43JQXF3JK5";
@@ -821,6 +892,52 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $response = $this->userManagement->deleteOrganizationMembership($organizationMembershipId);
 
         $this->assertSame($response, []);
+    }
+
+    public function testDeactivateOrganizationMembership()
+    {
+        $organizationMembershipId = "om_01E4ZCR3C56J083X43JQXF3JK5";
+        $path = "user_management/organization_memberships/{$organizationMembershipId}/deactivate";
+
+        $result = $this->organizationMembershipResponseFixture("inactive");
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $path,
+            null,
+            null,
+            true,
+            $result
+        );
+
+        $organizationMembership = $this->organizationMembershipFixture();
+
+        $response = $this->userManagement->deactivateOrganizationMembership($organizationMembershipId);
+
+        $this->assertSame(array_merge($organizationMembership, array("status" => "inactive")), $response->toArray());
+    }
+
+    public function testReactivateOrganizationMembership()
+    {
+        $organizationMembershipId = "om_01E4ZCR3C56J083X43JQXF3JK5";
+        $path = "user_management/organization_memberships/{$organizationMembershipId}/reactivate";
+
+        $result = $this->organizationMembershipResponseFixture();
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $path,
+            null,
+            null,
+            true,
+            $result
+        );
+
+        $organizationMembership = $this->organizationMembershipFixture();
+
+        $response = $this->userManagement->reactivateOrganizationMembership($organizationMembershipId);
+
+        $this->assertSame($organizationMembership, $response->toArray());
     }
 
     public function testSendInvitation()
@@ -1001,14 +1118,14 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    private function organizationMembershipResponseFixture()
+    private function organizationMembershipResponseFixture($status = "active")
     {
         return json_encode([
             "object" => "organization_membership",
             "id" => "om_01E4ZCR3C56J083X43JQXF3JK5",
             "user_id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
             "organization_id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
-            "status" => "active",
+            "status" => $status,
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z",
         ]);

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -902,7 +902,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $result = $this->organizationMembershipResponseFixture("inactive");
 
         $this->mockRequest(
-            Client::METHOD_POST,
+            Client::METHOD_PUT,
             $path,
             null,
             null,
@@ -925,7 +925,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $result = $this->organizationMembershipResponseFixture();
 
         $this->mockRequest(
-            Client::METHOD_POST,
+            Client::METHOD_PUT,
             $path,
             null,
             null,


### PR DESCRIPTION
## Description
Add organization membership deactivate and reactivate API methods.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
