### PR TITLE
Auth with refresh token and fix some tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.15|^3.6",
-    "phpunit/phpunit": "^5.7|^9.5.10"
+    "phpunit/phpunit": "^11"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.15|^3.6",
-    "phpunit/phpunit": "^11"
+    "phpunit/phpunit": "^10"
   },
   "autoload": {
     "psr-4": {
@@ -38,8 +38,8 @@
   },
   "config": {
     "allow-plugins": {
-        "workos-php/*": true,
-        "kylekatarnls/update-helper": true
+      "workos-php/*": true,
+      "kylekatarnls/update-helper": true
     }
   }
 }

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -709,7 +709,7 @@ class UserManagement
     /**
      * Authenticate with Refresh Token
      * @param string $clientId This value can be obtained from the API Keys page in the WorkOS dashboard.
-     * @param string $refreshToken The refresh token used to obtain a new access token     
+     * @param string $refreshToken The refresh token used to obtain a new access token
      * @param string|null $ipAddress The IP address of the request from the user who is attempting to authenticate.
      * @param string|null $userAgent The user agent of the request from the user who is attempting to authenticate.
      *
@@ -1007,11 +1007,11 @@ class UserManagement
 
     /**
      * Returns the public key host that is used for verifying access tokens.
-     * 
+     *
      * @param string $clientId This value can be obtained from the API Keys page in the WorkOS dashboard.
-     * 
+     *
      * @throws Exception\UnexpectedValueException
-     * 
+     *
      * @return string
      */
     public function getJwksUrl(string $clientId)

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -1010,12 +1010,14 @@ class UserManagement
      * 
      * @param string $clientId This value can be obtained from the API Keys page in the WorkOS dashboard.
      * 
+     * @throws Exception\UnexpectedValueException
+     * 
      * @return string
      */
     public function getJwksUrl(string $clientId)
     {
-        if (!isset($clientId)) {
-            throw new Exception('$clientId must be a valid client ID');
+        if (!isset($clientId) || empty($clientId)) {
+            throw new Exception\UnexpectedValueException("clientId must not be empty");
         }
 
         $baseUrl = WorkOS::getApiBaseUrl();

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -29,7 +29,7 @@ class UserManagement
      *
      * @return \WorkOS\Resource\User
      */
-    public function createUser($email, $password, $firstName, $lastName, $emailVerified, $passwordHash = null, $passwordHashType = null)
+    public function createUser($email, $password = null, $firstName = null, $lastName = null, $emailVerified = null, $passwordHash = null, $passwordHashType = null)
     {
         $path = "user_management/users";
         $params = [
@@ -272,8 +272,8 @@ class UserManagement
      *      array \WorkOS\Resource\OrganizationMembership instances
      */
     public function listOrganizationMemberships(
-        $userId,
-        $organizationId,
+        $userId = null,
+        $organizationId = null,
         $limit = self::DEFAULT_PAGE_SIZE,
         $before = null,
         $after = null,
@@ -789,7 +789,7 @@ class UserManagement
      *
      * @return \WorkOS\Resource\UserResponse
      */
-    public function enrollAuthFactor($userId, $type, $totpIssuer, $totpUser)
+    public function enrollAuthFactor($userId, $type, $totpIssuer = null, $totpUser = null)
     {
         $path = "user_management/users/{$userId}/auth_factors";
 

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -544,7 +544,7 @@ class UserManagement
     /**
      * Authenticate a User with Password
      *
-     * @param string $clientId This value can be obtained from the Configuration page in the WorkOS dashboard.
+     * @param string $clientId This value can be obtained from the API Keys page in the WorkOS dashboard.
      * @param string $email The email address of the user.
      * @param string $password The password of the user.
      * @param string|null $ipAddress The IP address of the request from the user who is attempting to authenticate.
@@ -575,7 +575,7 @@ class UserManagement
     /**
      * Authenticate a User with Selected Organization
      *
-     * @param string $clientId This value can be obtained from the Configuration page in the WorkOS dashboard.
+     * @param string $clientId This value can be obtained from the API Keys page in the WorkOS dashboard.
      * @param string $pendingAuthenticationToken Token returned from a failed authentication attempt due to organization selection being required.
      * @param string $organizationId The Organization ID the user selected.
      * @param string|null $ipAddress The IP address of the request from the user who is attempting to authenticate.
@@ -612,7 +612,7 @@ class UserManagement
      * Authenticate an OAuth or SSO User with a Code
      * This should be used for "Hosted AuthKit" and "OAuth or SSO" UserAuthentications
      *
-     * @param string $clientId This value can be obtained from the Configuration page in the WorkOS dashboard.
+     * @param string $clientId This value can be obtained from the API Keys page in the WorkOS dashboard.
      * @param string $code The authorization value which was passed back as a query parameter in the callback to the Redirect URI.
      * @param string|null $ipAddress The IP address of the request from the user who is attempting to authenticate.
      * @param string|null $userAgent The user agent of the request from the user who is attempting to authenticate.
@@ -641,7 +641,7 @@ class UserManagement
     /**
      * Authenticates a user with an unverified email and verifies their email address.
      *
-     * @param string $clientId This value can be obtained from the Configuration page in the WorkOS dashboard.
+     * @param string $clientId This value can be obtained from the API Keys page in the WorkOS dashboard.
      * @param string $code The authorization value which was passed back as a query parameter in the callback to the Redirect URI.
      * @param string $pendingAuthenticationToken Token returned from a failed authentication attempt due to organization selection being required.
      * @param string|null $ipAddress The IP address of the request from the user who is attempting to authenticate.
@@ -672,7 +672,7 @@ class UserManagement
     /**
      * Authenticate with Magic Auth
      *
-     * @param string $clientId This value can be obtained from the Configuration page in the WorkOS dashboard.
+     * @param string $clientId This value can be obtained from the API Keys page in the WorkOS dashboard.
      * @param string $code The authorization value which was passed back as a query parameter in the callback to the Redirect URI.
      * @param string $userId The unique ID of the user.
      * @param string|null $ipAddress The IP address of the request from the user who is attempting to authenticate.
@@ -708,7 +708,7 @@ class UserManagement
 
     /**
      * Authenticate with Refresh Token
-     * @param string $clientId This value can be obtained from the Configuration page in the WorkOS dashboard.
+     * @param string $clientId This value can be obtained from the API Keys page in the WorkOS dashboard.
      * @param string $refreshToken The refresh token used to obtain a new access token     
      * @param string|null $ipAddress The IP address of the request from the user who is attempting to authenticate.
      * @param string|null $userAgent The user agent of the request from the user who is attempting to authenticate.
@@ -741,7 +741,7 @@ class UserManagement
     /**
      * Authenticate with TOTP
      *
-     * @param string $clientId This value can be obtained from the Configuration page in the WorkOS dashboard.
+     * @param string $clientId This value can be obtained from the API Keys page in the WorkOS dashboard.
      * @param string $pendingAuthenticationToken
      * @param string $authenticationChallengeId
      * @param string $code
@@ -1003,5 +1003,23 @@ class UserManagement
         );
 
         return $response;
+    }
+
+    /**
+     * Returns the public key host that is used for verifying access tokens.
+     * 
+     * @param string $clientId This value can be obtained from the API Keys page in the WorkOS dashboard.
+     * 
+     * @return string
+     */
+    public function getJwksUrl(string $clientId)
+    {
+        if (!isset($clientId)) {
+            throw new Exception('$clientId must be a valid client ID');
+        }
+
+        $baseUrl = WorkOS::getApiBaseUrl();
+
+        return "{$baseUrl}/sso/jwks/{$clientId}";
     }
 }

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -707,6 +707,38 @@ class UserManagement
     }
 
     /**
+     * Authenticate with Refresh Token
+     * @param string $clientId This value can be obtained from the Configuration page in the WorkOS dashboard.
+     * @param string $refreshToken The refresh token used to obtain a new access token     
+     * @param string|null $ipAddress The IP address of the request from the user who is attempting to authenticate.
+     * @param string|null $userAgent The user agent of the request from the user who is attempting to authenticate.
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\AuthenticationResponse
+     */
+    public function authenticateWithRefreshToken(
+        $clientId,
+        $refreshToken,
+        $ipAddress = null,
+        $userAgent = null
+    ) {
+        $path = "user_management/authenticate";
+        $params = [
+            "client_id" => $clientId,
+            "refresh_token" => $refreshToken,
+            "ip_address" => $ipAddress,
+            "user_agent" => $userAgent,
+            "grant_type" => "refresh_token",
+            "client_secret" => WorkOS::getApiKey()
+        ];
+
+        $response = Client::request(Client::METHOD_POST, $path, null, $params, true);
+
+        return Resource\AuthenticationResponse::constructFromResponse($response);
+    }
+
+    /**
      * Authenticate with TOTP
      *
      * @param string $clientId This value can be obtained from the Configuration page in the WorkOS dashboard.

--- a/tests/WorkOS/AuditLogsTest.php
+++ b/tests/WorkOS/AuditLogsTest.php
@@ -113,7 +113,7 @@ class AuditLogsTest extends \PHPUnit\Framework\TestCase
     {
         $auditLogExportId = "123";
 
-        $path = "audit_logs/exports/${auditLogExportId}";
+        $path = "audit_logs/exports/{$auditLogExportId}";
 
         $result = $this->getExportResponseFixture();
 

--- a/tests/WorkOS/ClientTest.php
+++ b/tests/WorkOS/ClientTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 class ClientTest extends \PHPUnit\Framework\TestCase
 {
     use TestHelper;
-    
+
     #[DataProvider('requestExceptionTestProvider')]
     public function testClientThrowsRequestExceptions($statusCode, $exceptionClass)
     {

--- a/tests/WorkOS/ClientTest.php
+++ b/tests/WorkOS/ClientTest.php
@@ -2,13 +2,14 @@
 
 namespace WorkOS;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
 class ClientTest extends \PHPUnit\Framework\TestCase
 {
     use TestHelper;
-
-    /**
-     * @dataProvider requestExceptionTestProvider
-     */
+    
+    #[DataProvider('requestExceptionTestProvider')]
     public function testClientThrowsRequestExceptions($statusCode, $exceptionClass)
     {
         $this->withApiKeyAndClientId();
@@ -30,9 +31,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         Client::request(Client::METHOD_GET, $path);
     }
 
-    /**
-     * @dataProvider requestExceptionTestProvider
-     */
+    #[DataProvider('requestExceptionTestProvider')]
     public function testClientThrowsRequestExceptionsIncludeRequestId($statusCode, $exceptionClass)
     {
         $this->withApiKeyAndClientId();
@@ -61,9 +60,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $this->fail("Expected exception of type " . $exceptionClass . " not thrown.");
     }
 
-    /**
-     * @dataProvider requestExceptionTestProvider
-     */
+    #[DataProvider('requestExceptionTestProvider')]
     public function testClientThrowsRequestExceptionsWithBadMessage($statusCode, $exceptionClass)
     {
         $this->withApiKeyAndClientId();
@@ -90,9 +87,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @dataProvider requestExceptionTestProvider
-     */
+    #[DataProvider('requestExceptionTestProvider')]
     public function testClientThrowsRequestExceptionsWithMessageAndCode($statusCode, $exceptionClass)
     {
         $this->withApiKeyAndClientId();
@@ -121,9 +116,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @dataProvider requestExceptionTestProvider
-     */
+    #[DataProvider('requestExceptionTestProvider')]
     public function testClientThrowsRequestExceptionsWithErrorAndErrorDescription($statusCode, $exceptionClass)
     {
         $this->withApiKeyAndClientId();
@@ -152,9 +145,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @dataProvider requestExceptionTestProvider
-     */
+    #[DataProvider('requestExceptionTestProvider')]
     public function testClientThrowsRequestExceptionsWithErrors($statusCode, $exceptionClass)
     {
         $this->withApiKeyAndClientId();
@@ -183,7 +174,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     }
 
     // Providers
-    public function requestExceptionTestProvider()
+    public static function requestExceptionTestProvider()
     {
         return [
             [400, Exception\BadRequestException::class],

--- a/tests/WorkOS/DirectorySyncTest.php
+++ b/tests/WorkOS/DirectorySyncTest.php
@@ -49,7 +49,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
     public function testGetDirectory()
     {
         $directoryId = "directory_id";
-        $directoryPath = "directories/${directoryId}";
+        $directoryPath = "directories/{$directoryId}";
 
         $result = $this->getDirectoryResponseFixture();
 
@@ -71,7 +71,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
     public function testGetGroup()
     {
         $directoryGroup = "directory_grp_id";
-        $groupPath = "directory_groups/${directoryGroup}";
+        $groupPath = "directory_groups/{$directoryGroup}";
 
         $result = $this->groupResponseFixture();
 
@@ -120,7 +120,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
     public function testGetUser()
     {
         $directoryUser = "directory_usr_id";
-        $userPath = "directory_users/${directoryUser}";
+        $userPath = "directory_users/{$directoryUser}";
 
         $result = $this->userResponseFixture();
 
@@ -142,7 +142,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
     public function testGetUserPrimaryEmail()
     {
         $directoryUser = "directory_usr_id";
-        $userPath = "directory_users/${directoryUser}";
+        $userPath = "directory_users/{$directoryUser}";
         $expectedEmail = "yoon@seri.com";
         $result = $this->userResponseFixture();
 
@@ -164,7 +164,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
     public function testGetUserPrimaryEmailNoPrimaryEmail()
     {
         $directoryUser = "directory_usr_id";
-        $userPath = "directory_users/${directoryUser}";
+        $userPath = "directory_users/{$directoryUser}";
         $expectedEmail = null;
         $result = $this->userResponseFixtureNoEmail();
 
@@ -213,7 +213,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
     public function testDeleteDirectory()
     {
         $directory = "directory_id";
-        $directoryPath = "directories/${directory}";
+        $directoryPath = "directories/{$directory}";
         $responseCode = 204;
 
         $this->mockRequest(

--- a/tests/WorkOS/MFATest.php
+++ b/tests/WorkOS/MFATest.php
@@ -159,7 +159,7 @@ class MFATest extends \PHPUnit\Framework\TestCase
     public function testGetFactor()
     {
         $authenticationFactorId = "auth_factor_01FXNWW32G7F3MG8MYK5D1HJJM";
-        $getFactorPath = "auth/factors/${authenticationFactorId}";
+        $getFactorPath = "auth/factors/{$authenticationFactorId}";
 
         $result = $this->getFactorResponseFixture();
 
@@ -181,7 +181,7 @@ class MFATest extends \PHPUnit\Framework\TestCase
     public function testDeleteFactor()
     {
         $authenticationFactorId = "auth_factor_01FXNWW32G7F3MG8MYK5D1HJJM";
-        $deleteFactorPath = "auth/factors/${authenticationFactorId}";
+        $deleteFactorPath = "auth/factors/{$authenticationFactorId}";
         $responseCode = 200;
 
         $this->mockRequest(

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -18,7 +18,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         $this->withApiKeyAndClientId();
         $this->sso = new SSO();
     }
-    
+
     #[DataProvider('authorizationUrlTestProvider')]
     public function testAuthorizationURLExpectedParams(
         $domain,

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -2,6 +2,9 @@
 
 namespace WorkOS;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
 class SSOTest extends \PHPUnit\Framework\TestCase
 {
     use TestHelper {
@@ -15,10 +18,8 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         $this->withApiKeyAndClientId();
         $this->sso = new SSO();
     }
-
-    /**
-     * @dataProvider authorizationUrlTestProvider
-     */
+    
+    #[DataProvider('authorizationUrlTestProvider')]
     public function testAuthorizationURLExpectedParams(
         $domain,
         $redirectUri,
@@ -114,7 +115,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
     public function testGetConnection()
     {
         $connection = "connection_id";
-        $connectionPath = "connections/${connection}";
+        $connectionPath = "connections/{$connection}";
 
         $result = $this->connectionResponseFixture();
 
@@ -166,7 +167,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
     public function testDeleteConnection()
     {
         $connection = "connection_id";
-        $connectionPath = "connections/${connection}";
+        $connectionPath = "connections/{$connection}";
         $responseCode = 204;
 
         $this->mockRequest(
@@ -186,7 +187,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
 
     // Providers
 
-    public function authorizationUrlTestProvider()
+    public static function authorizationUrlTestProvider()
     {
         return [
             [null, null, null, Resource\ConnectionType::GoogleOAuth, null],

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -2,6 +2,9 @@
 
 namespace WorkOS;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
 class UserManagementTest extends \PHPUnit\Framework\TestCase
 {
     use TestHelper {
@@ -113,9 +116,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @dataProvider authorizationUrlTestDataProvider
-     */
+    #[DataProvider('authorizationUrlTestDataProvider')]
     public function testAuthorizationURLExpectedParams(
         $redirectUri,
         $state,
@@ -367,6 +368,36 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($enrollUserAuthChallengeFixture, $enrollFactorTotp->authenticationChallenge->toArray());
     }
 
+    public function testAuthenticateWithRefreshToken()
+    {
+        $path = "user_management/authenticate";
+        WorkOS::setApiKey("sk_test_12345");
+        $result = $this->UserResponseFixture();
+
+        $params = [
+            "client_id" => "project_0123456",            
+            "refresh_token" => "Xw0NsCVXMBf7svAoIoKBmkpEK",
+            "ip_address" => null,
+            "user_agent" => null,            
+            "grant_type" => "refresh_token",
+            "client_secret" => WorkOS::getApiKey()
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $path,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $userFixture = $this->userFixture();
+
+        $response = $this->userManagement->authenticateWithRefreshToken("project_0123456", "Xw0NsCVXMBf7svAoIoKBmkpEK");
+        $this->assertSame($userFixture, $response->user->toArray());
+    }
+
     public function testAuthenticateWithTotp()
     {
         $path = "user_management/authenticate";
@@ -398,8 +429,6 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $response = $this->userManagement->authenticateWithTotp("project_0123456", "cTDQJTTkTkkVYxQUlKBIxEsFs", "auth_challenge_01H96FETXGTW1QMBSBT2T36PW0", "123456");
         $this->assertSame($userFixture, $response->user->toArray());
     }
-
-
 
     public function testAuthenticateWithMagicAuth()
     {

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -964,6 +964,18 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($response->toArray(), $expected);
     }
 
+    public function testGetJwksUrl()
+    {
+        $clientId = "12345";
+
+        $result = $this->userManagement->getJwksUrl($clientId);
+
+        $baseUrl = WorkOS::getApiBaseUrl();
+        $expected = "{$baseUrl}/sso/jwks/{$clientId}";
+
+        $this->assertSame($result, $expected);
+    }
+
     //Fixtures
 
     private function invitationResponseFixture()

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -976,6 +976,17 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($result, $expected);
     }
 
+    public function testGetJwksUrlException() 
+    {
+        $result = "clientId must not be empty";
+
+        try {
+            $this->userManagement->getJwksUrl('');
+        } catch (Exception\UnexpectedValueException $e) {
+            $this->assertEquals($e->getMessage(), $result);
+        }
+    }
+
     //Fixtures
 
     private function invitationResponseFixture()

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -375,10 +375,10 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $result = $this->UserResponseFixture();
 
         $params = [
-            "client_id" => "project_0123456",            
+            "client_id" => "project_0123456",
             "refresh_token" => "Xw0NsCVXMBf7svAoIoKBmkpEK",
             "ip_address" => null,
-            "user_agent" => null,            
+            "user_agent" => null,
             "grant_type" => "refresh_token",
             "client_secret" => WorkOS::getApiKey()
         ];
@@ -976,7 +976,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($result, $expected);
     }
 
-    public function testGetJwksUrlException() 
+    public function testGetJwksUrlException()
     {
         $result = "clientId must not be empty";
 


### PR DESCRIPTION
## Description
This PR: 

- Adds support for authentication with a refresh token
- Adds `getJwksUrl` helper method
- Upgrades phpunit to v10
- Fixes several language deprecations
- Fixes issues with method properties which should be optional https://github.com/workos/workos-php/issues/228

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
