### PR TITLE
Fix bug with URL parsing

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -1082,7 +1082,7 @@ class UserManagement
 
         $baseUrl = WorkOS::getApiBaseUrl();
 
-        return "{$baseUrl}/sso/jwks/{$clientId}";
+        return "{$baseUrl}sso/jwks/{$clientId}";
     }
 
     /**
@@ -1100,6 +1100,6 @@ class UserManagement
 
         $baseUrl = WorkOS::getApiBaseUrl();
 
-        return "{$baseUrl}/user_management/sessions/logout?session_id={$sessionId}";
+        return "{$baseUrl}user_management/sessions/logout?session_id={$sessionId}";
     }
 }

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -1088,7 +1088,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $result = $this->userManagement->getJwksUrl($clientId);
 
         $baseUrl = WorkOS::getApiBaseUrl();
-        $expected = "{$baseUrl}/sso/jwks/{$clientId}";
+        $expected = "{$baseUrl}sso/jwks/{$clientId}";
 
         $this->assertSame($result, $expected);
     }
@@ -1111,7 +1111,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $result = $this->userManagement->getLogoutUrl($sessionId);
 
         $baseUrl = WorkOS::getApiBaseUrl();
-        $expected = "{$baseUrl}/user_management/sessions/logout?session_id={$sessionId}";
+        $expected = "{$baseUrl}user_management/sessions/logout?session_id={$sessionId}";
 
         $this->assertSame($result, $expected);
     }


### PR DESCRIPTION
## Description
Fixes bug where double forward slashes were being inserted.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
