### PR TITLE
Add methods and events for email verification and password reset

### DIFF
--- a/lib/Resource/EmailVerification.php
+++ b/lib/Resource/EmailVerification.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class EmailVerification.
+ */
+
+class EmailVerification extends BaseWorkOSResource
+{
+    public const RESOURCE_TYPE = "email_verification";
+
+    public const RESOURCE_ATTRIBUTES = [
+        "object",
+        "id",
+        "userId",
+        "email",
+        "expiresAt",
+        "code",
+        "createdAt",
+        "updatedAt"
+    ];
+
+    public const RESPONSE_TO_RESOURCE_KEY = [
+        "object" => "object",
+        "id" => "id",
+        "user_id" => "userId",
+        "email" => "email",
+        "expires_at" => "expiresAt",
+        "code" => "code",
+        "created_at" => "createdAt",
+        "updated_at" => "updatedAt"
+    ];
+}

--- a/lib/Resource/Invitation.php
+++ b/lib/Resource/Invitation.php
@@ -21,6 +21,7 @@ class Invitation extends BaseWorkOSResource
         "token",
         "acceptInvitationUrl",
         "organizationId",
+        "inviterUserId",
         "createdAt",
         "updatedAt"
     ];
@@ -36,6 +37,7 @@ class Invitation extends BaseWorkOSResource
         "token" => "token",
         "accept_invitation_url" => "acceptInvitationUrl",
         "organization_id" => "organizationId",
+        "inviter_user_id" => "inviterUserId",
         "created_at" => "createdAt",
         "updated_at" => "updatedAt"
     ];

--- a/lib/Resource/PasswordReset.php
+++ b/lib/Resource/PasswordReset.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class PasswordReset.
+ */
+
+class PasswordReset extends BaseWorkOSResource
+{
+    public const RESOURCE_TYPE = "password_reset";
+
+    public const RESOURCE_ATTRIBUTES = [
+        "object",
+        "id",
+        "userId",
+        "email",
+        "passwordResetToken",
+        "passwordResetUrl",
+        "expiresAt",
+        "createdAt",
+    ];
+
+    public const RESPONSE_TO_RESOURCE_KEY = [
+        "object" => "object",
+        "id" => "id",
+        "user_id" => "userId",
+        "email" => "email",
+        "password_reset_token" => "passwordResetToken",
+        "password_reset_url" => "passwordResetUrl",
+        "expires_at" => "expiresAt",
+        "created_at" => "createdAt",
+    ];
+}

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -889,6 +889,30 @@ class UserManagement
     }
 
     /**
+     * Get an email verification object
+     *
+     * @param string $emailVerificationId ID of the email verification object
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\EmailVerification
+     */
+    public function getEmailVerification($emailVerificationId)
+    {
+        $path = "/user_management/email_verification/{$emailVerificationId}";
+
+        $response = Client::request(
+            Client::METHOD_GET,
+            $path,
+            null,
+            null,
+            true
+        );
+
+        return Resource\EmailVerification::constructFromResponse($response);
+    }
+
+    /**
      * Create Email Verification Challenge.
      *
      * @param string $userId The unique ID of the User whose email address will be verified.
@@ -930,6 +954,59 @@ class UserManagement
     }
 
     /**
+     * Get a password reset object
+     *
+     * @param string $passwordResetId ID of the password reset object
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\PasswordReset
+     */
+    public function getPasswordReset($passwordResetId)
+    {
+        $path = "/user_management/password_reset/{$passwordResetId}";
+
+        $response = Client::request(
+            Client::METHOD_GET,
+            $path,
+            null,
+            null,
+            true
+        );
+
+        return Resource\PasswordReset::constructFromResponse($response);
+    }
+
+    /**
+     * Creates a password reset token
+     *
+     * @param string $email The email address of the user
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\PasswordReset
+     */
+    public function createPasswordReset(
+        $email,
+    ) {
+        $path = "/user_management/password_reset";
+
+        $params = [
+            "email" => $email
+        ];
+
+        $response = Client::request(
+            Client::METHOD_POST,
+            $path,
+            null,
+            $params,
+            true
+        );
+
+        return Resource\PasswordReset::constructFromResponse($response);
+    }
+
+    /**
      * Create Password Reset Email.
      *
      * @param string $email The email of the user that wishes to reset their password.
@@ -941,6 +1018,10 @@ class UserManagement
      */
     public function sendPasswordResetEmail($email, $passwordResetUrl)
     {
+        $msg = "'sendPasswordResetEmail' is deprecated. Please use 'createPasswordReset' instead. This method will be removed in a future major version.";
+
+        error_log($msg);
+
         $path = "user_management/password_reset/send";
 
         $params = [

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -492,6 +492,29 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($user, $response->toArray());
     }
 
+    public function testGetEmailVerification()
+    {
+        $emailVerificationId = "email_verification_01E4ZCR3C56J083X43JQXF3JK5";
+        $path = "/user_management/email_verification/{$emailVerificationId}";
+
+        $result = $this->emailVerificationResponseFixture();
+
+        $this->mockRequest(
+            Client::METHOD_GET,
+            $path,
+            null,
+            null,
+            true,
+            $result
+        );
+
+        $response = $this->userManagement->getEmailVerification($emailVerificationId);
+
+        $expected = $this->emailVerificationFixture();
+
+        $this->assertSame($response->toArray(), $expected);
+    }
+
     public function testSendVerificationEmail()
     {
         $userId = "user_01E4ZCR3C56J083X43JQXF3JK5";
@@ -539,6 +562,57 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->userManagement->verifyEmail("user_01H7X1M4TZJN5N4HG4XXMA1234", "01DMEK0J53CVMC32CK5SE0KZ8Q");
         $this->assertSame($userFixture, $response->user->toArray());
+    }
+
+    public function testGetPasswordReset()
+    {
+        $passwordResetId = "password_reset_01E4ZCR3C56J083X43JQXF3JK5";
+        $path = "/user_management/password_reset/{$passwordResetId}";
+
+        $result = $this->passwordResetResponseFixture();
+
+        $this->mockRequest(
+            Client::METHOD_GET,
+            $path,
+            null,
+            null,
+            true,
+            $result
+        );
+
+        $response = $this->userManagement->getPasswordReset($passwordResetId);
+
+        $expected = $this->passwordResetFixture();
+
+        $this->assertSame($response->toArray(), $expected);
+    }
+
+    public function testCreatePasswordReset()
+    {
+        $path = "/user_management/password_reset";
+
+        $result = $this->passwordResetResponseFixture();
+
+        $params = [
+            "email" => "someemail@test.com",
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $path,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $response = $this->userManagement->createPasswordReset(
+            "someemail@test.com",
+        );
+
+        $expected = $this->passwordResetFixture();
+
+        $this->assertSame($response->toArray(), $expected);
     }
 
     public function testSendPasswordResetEmail()
@@ -1140,8 +1214,9 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "revoked_at" => "2021-07-01T19:07:33.155Z",
             "expires_at" => "2021-07-01T19:07:33.155Z",
             "token" => "Z1uX3RbwcIl5fIGJJJCXXisdI",
-            "accept_invitation_url" => "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+            "accept_invitation_url" => "https://your-app.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
             "organization_id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
+            "inviter_user_id" => "user_01HYKE1DMN34HMHC180HJMF4AQ",
             "created_at" => "2021-07-01T19:07:33.155Z",
             "updated_at" => "2021-07-01T19:07:33.155Z",
         ]);
@@ -1158,8 +1233,9 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "revokedAt" => "2021-07-01T19:07:33.155Z",
             "expiresAt" => "2021-07-01T19:07:33.155Z",
             "token" => "Z1uX3RbwcIl5fIGJJJCXXisdI",
-            "acceptInvitationUrl" => "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+            "acceptInvitationUrl" => "https://your-app.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
             "organizationId" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
+            "inviterUserId" => "user_01HYKE1DMN34HMHC180HJMF4AQ",
             "createdAt" => "2021-07-01T19:07:33.155Z",
             "updatedAt" => "2021-07-01T19:07:33.155Z",
         ];
@@ -1179,8 +1255,9 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
                         "revoked_at" => "2021-07-01T19:07:33.155Z",
                         "expires_at" => "2021-07-01T19:07:33.155Z",
                         "token" => "Z1uX3RbwcIl5fIGJJJCXXisdI",
-                        "accept_invitation_url" => "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+                        "accept_invitation_url" => "https://your-app.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
                         "organization_id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
+                        "inviter_user_id" => "user_01HYKE1DMN34HMHC180HJMF4AQ",
                         "created_at" => "2021-07-01T19:07:33.155Z",
                         "updated_at" => "2021-07-01T19:07:33.155Z",
                     ]
@@ -1388,6 +1465,62 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "code" => "123456",
             "createdAt" => "2021-07-01T19:07:33.155Z",
             "updatedAt" => "2021-07-01T19:07:33.155Z",
+        ];
+    }
+
+    private function emailVerificationResponseFixture()
+    {
+        return json_encode([
+            "object" => "email_verification",
+            "id" => "email_verification_01E4ZCR3C56J083X43JQXF3JK5",
+            "user_id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
+            "email" => "someemail@test.com",
+            "expires_at" => "2021-07-01T19:07:33.155Z",
+            "code" => "123456",
+            "created_at" => "2021-07-01T19:07:33.155Z",
+            "updated_at" => "2021-07-01T19:07:33.155Z",
+        ]);
+    }
+
+    private function emailVerificationFixture()
+    {
+        return [
+            "object" => "email_verification",
+            "id" => "email_verification_01E4ZCR3C56J083X43JQXF3JK5",
+            "userId" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
+            "email" => "someemail@test.com",
+            "expiresAt" => "2021-07-01T19:07:33.155Z",
+            "code" => "123456",
+            "createdAt" => "2021-07-01T19:07:33.155Z",
+            "updatedAt" => "2021-07-01T19:07:33.155Z",
+        ];
+    }
+
+    private function passwordResetResponseFixture()
+    {
+        return json_encode([
+            "object" => "password_reset",
+            "id" => "password_reset_01E4ZCR3C56J083X43JQXF3JK5",
+            "user_id" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
+            "email" => "someemail@test.com",
+            "password_reset_token" => "Z1uX3RbwcIl5fIGJJJCXXisdI",
+            "password_reset_url" => "https://your-app.com/reset-password?token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+            "expires_at" => "2021-07-01T19:07:33.155Z",
+            "created_at" => "2021-07-01T19:07:33.155Z",
+        ]);
+    }
+
+    private function passwordResetFixture()
+    {
+        return [
+            "object" => "password_reset",
+            "id" => "password_reset_01E4ZCR3C56J083X43JQXF3JK5",
+            "userId" => "user_01H7X1M4TZJN5N4HG4XXMA1234",
+            "email" => "someemail@test.com",
+            "passwordResetToken" => "Z1uX3RbwcIl5fIGJJJCXXisdI",
+            "passwordResetUrl" => "https://your-app.com/reset-password?token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+            "expiresAt" => "2021-07-01T19:07:33.155Z",
+            "createdAt" => "2021-07-01T19:07:33.155Z",
         ];
     }
 


### PR DESCRIPTION
## Description

- Add `inviterUserID` to invitation object
- Add `GET /user_management/email_verification/:id` endpoint
- Add `GET /user_management/password_reset/:id` and `POST /user_management/password_reset` endpoints
- Deprecate current send password reset endpoint

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```
https://github.com/workos/workos/pull/27414
If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
