### PR TITLE
Add find invitation by token method

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -435,6 +435,30 @@ class UserManagement
     }
 
     /**
+     * Find an Invitation by Token
+     *
+     * @param string $invitationToken The token of the Invitation
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\Invitation
+     */
+    public function findInvitationByToken($invitationToken)
+    {
+        $path = "/user_management/invitations/by_token/{$invitationToken}";
+
+        $response = Client::request(
+            Client::METHOD_GET,
+            $path,
+            null,
+            null,
+            true
+        );
+
+        return Resource\Invitation::constructFromResponse($response);
+    }
+
+    /**
      * List Invitations
      *
      * @param string|null $email Email of the invitee

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -1102,6 +1102,29 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($response->toArray(), $expected);
     }
 
+    public function testFindInvitationByToken()
+    {
+        $invitationToken = "Z1uX3RbwcIl5fIGJJJCXXisdI";
+        $path = "/user_management/invitations/by_token/{$invitationToken}";
+
+        $result = $this->invitationResponseFixture();
+
+        $this->mockRequest(
+            Client::METHOD_GET,
+            $path,
+            null,
+            null,
+            true,
+            $result
+        );
+
+        $response = $this->userManagement->findInvitationByToken($invitationToken);
+
+        $expected = $this->invitationFixture();
+
+        $this->assertSame($response->toArray(), $expected);
+    }
+
     public function testListInvitations()
     {
         $path = "/user_management/invitations";


### PR DESCRIPTION
## Description

Exposes find invitation by token API endpoint

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/27785
