### PR TITLE
Add missing OAuth constants

### DIFF
--- a/lib/Resource/ConnectionType.php
+++ b/lib/Resource/ConnectionType.php
@@ -10,9 +10,11 @@ namespace WorkOS\Resource;
 class ConnectionType
 {
     public const ADFSSAML = "ADFSSAML";
+    public const AppleOAuth = "AppleOAuth";
     public const AzureSAML = "AzureSAML";
     public const GenericOIDC = "GenericOIDC";
     public const GenericSAML = "GenericSAML";
+    public const GitHubOAuth = "GitHubOAuth";
     public const GoogleOAuth = "GoogleOAuth";
     public const GoogleSAML = "GoogleSAML";
     public const MagicLink = "MagicLink";

--- a/lib/Resource/ConnectionType.php
+++ b/lib/Resource/ConnectionType.php
@@ -18,6 +18,7 @@ class ConnectionType
     public const GoogleOAuth = "GoogleOAuth";
     public const GoogleSAML = "GoogleSAML";
     public const MagicLink = "MagicLink";
+    public const MicrosoftOAuth = "MicrosoftOAuth";
     public const OneLoginSAML = "OneLoginSAML";
     public const OktaSAML = "OktaSAML";
     public const PingFederateSAML = "PingFederateSAML";

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -575,6 +575,8 @@ class UserManagement
 
         $supportedProviders = [
             self::AUTHORIZATION_PROVIDER_AUTHKIT,
+            self::AUTHORIZATION_PROVIDER_APPLE_OAUTH,
+            self::AUTHORIZATION_PROVIDER_GITHUB_OAUTH,
             self::AUTHORIZATION_PROVIDER_GOOGLE_OAUTH,
             self::AUTHORIZATION_PROVIDER_MICROSOFT_OAUTH
         ];

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -11,6 +11,8 @@ class UserManagement
     public const DEFAULT_TOKEN_EXPIRATION = 1440;
 
     public const AUTHORIZATION_PROVIDER_AUTHKIT = "authkit";
+    public const AUTHORIZATION_PROVIDER_APPLE_OAUTH = "AppleOAuth";
+    public const AUTHORIZATION_PROVIDER_GITHUB_OAUTH = "GitHubOAuth";
     public const AUTHORIZATION_PROVIDER_GOOGLE_OAUTH = "GoogleOAuth";
     public const AUTHORIZATION_PROVIDER_MICROSOFT_OAUTH = "MicrosoftOAuth";
 

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -105,7 +105,10 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public static function authorizationUrlTestDataProvider()
     {
         return [
+            [null, null, Resource\ConnectionType::AppleOAauth, null],
+            [null, null, Resource\ConnectionType::GitHubOAuth, null],
             [null, null, Resource\ConnectionType::GoogleOAuth, null],
+            [null, null, Resource\ConnectionType::MicrosoftOAuth, null],
             [null, null, null, "connection_123"],
             [null, null, null, null, "org_01FG7HGMY2CZZR2FWHTEE94VF0"],
             ["https://papagenos.com/auth/callback", null, null, "connection_123", null, "foo.com", null],

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -105,7 +105,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public static function authorizationUrlTestDataProvider()
     {
         return [
-            [null, null, Resource\ConnectionType::AppleOAauth, null],
+            [null, null, Resource\ConnectionType::AppleOAuth, null],
             [null, null, Resource\ConnectionType::GitHubOAuth, null],
             [null, null, Resource\ConnectionType::GoogleOAuth, null],
             [null, null, Resource\ConnectionType::MicrosoftOAuth, null],


### PR DESCRIPTION
## Description
Add `AppleOAuth` constants so SDK users can kick off login flows with Sign in with Apple.

The `GitHubOAuth` and 'MicrosoftOAuth` constants were partially missing, adding them too.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
