### PR TITLE
Deprecate `$allowProfilesOutsideOrganization` parameter

### DIFF
--- a/lib/Organizations.php
+++ b/lib/Organizations.php
@@ -79,12 +79,18 @@ class Organizations
     {
         $idempotencyKey ? $headers = array("Idempotency-Key: $idempotencyKey") : $headers = null;
         $organizationsPath = "organizations";
-        $params = [
-            "name" => $name,
-            "domains" => $domains,
-            "domain_data" => $domain_data,
-            "allow_profiles_outside_organization" => $allowProfilesOutsideOrganization
-        ];
+
+        $params = [ "name" => $name ];
+
+        if (isset($domains)) {
+            $params["domains"] = $domains;
+        }
+        if (isset($domain_data)) {
+            $params["domain_data"] = $domain_data;
+        }
+        if (isset($allowProfilesOutsideOrganization)) {
+            $params["allow_profiles_outside_organization"] = $allowProfilesOutsideOrganization;
+        }
 
         $response = Client::request(Client::METHOD_POST, $organizationsPath, $headers, $params, true);
 
@@ -106,12 +112,18 @@ class Organizations
     public function updateOrganization($organization, $domains = null, $name = null, $allowProfilesOutsideOrganization = null, $domain_data = null)
     {
         $organizationsPath = "organizations/{$organization}";
-        $params = [
-          "domains" => $domains,
-          "domain_data" => $domain_data,
-          "name" => $name,
-          "allow_profiles_outside_organization" => $allowProfilesOutsideOrganization
-        ];
+
+        $params = [ "name" => $name ];
+
+        if (isset($domains)) {
+            $params["domains"] = $domains;
+        }
+        if (isset($domain_data)) {
+            $params["domain_data"] = $domain_data;
+        }
+        if (isset($allowProfilesOutsideOrganization)) {
+            $params["allow_profiles_outside_organization"] = $allowProfilesOutsideOrganization;
+        }
 
         $response = Client::request(Client::METHOD_PUT, $organizationsPath, null, $params, true);
 

--- a/lib/Organizations.php
+++ b/lib/Organizations.php
@@ -67,8 +67,8 @@ class Organizations
      * @param string $name The name of the Organization.
      * @param null|array $domains [Deprecated] The domains of the Organization. Use domain_data instead.
      * @param null|array $domain_data The domains of the Organization.
-     * @param null|boolean $allowProfilesOutsideOrganization Whether Connections within the Organization allow profiles
-     *      that are outside of the Organization's configured User Email Domains.
+     * @param null|boolean $allowProfilesOutsideOrganization [Deprecated] If you need to allow sign-ins from
+     *      any email domain, contact support@workos.com.
      * @param null|string $idempotencyKey is a unique string that identifies a distinct organization
      *
      * @throws Exception\WorkOSException
@@ -104,8 +104,8 @@ class Organizations
      * @param null|array $domains [Deprecated] The domains of the Organization. Use domain_data instead.
      * @param null|array $domain_data The domains of the Organization.
      * @param null|string $name The name of the Organization.
-     * @param null|boolean $allowProfilesOutsideOrganization Whether Connections within the Organization allow profiles
-     *      that are outside of the Organization's configured User Email Domains.
+     * @param null|boolean $allowProfilesOutsideOrganization [Deprecated] If you need to allow sign-ins from
+     *      any email domain, contact support@workos.com.
      *
      * @throws Exception\WorkOSException
      */

--- a/tests/WorkOS/OrganizationsTest.php
+++ b/tests/WorkOS/OrganizationsTest.php
@@ -25,8 +25,6 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
         $params = [
             "name" => "Organization Name",
             "domains" => array("example.com"),
-            "domain_data" => null,
-            "allow_profiles_outside_organization" => null
         ];
 
         $this->mockRequest(
@@ -52,12 +50,10 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
 
         $params = [
             "name" => "Organization Name",
-            "domains" => null,
             "domain_data" => array([
                 "domain" => "example.com",
                 "state" => "verified",
             ]),
-            "allow_profiles_outside_organization" => null
         ];
 
         $this->mockRequest(
@@ -85,13 +81,11 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
         $result = $this->createOrganizationResponseFixture();
 
         $params = [
-            "domains" => null,
+            "name" => null,
             "domain_data" => array([
                 "domain" => "example.com",
                 "state" => "verified",
             ]),
-            "name" => null,
-            "allow_profiles_outside_organization" => null,
         ];
 
         $this->mockRequest(
@@ -121,8 +115,6 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
         $params = [
             "name" => "Organization Name",
             "domains" => array("example.com"),
-            "domain_data" => null,
-            "allow_profiles_outside_organization" => null
         ];
 
         $this->mockRequest(


### PR DESCRIPTION
## Description

Deprecates the `$allowProfilesOutsideOrganization` parameter. Additionally, updates the create/update Organization methods to only serialize these options if an actual value has been passed.

Previously, `null` was always sent, which was fine for this particular endpoint, but is not a pattern that is guaranteed to have the same semantics everywhere.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
