### PR TITLE
Remove leading slash from UM functions

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -389,7 +389,7 @@ class UserManagement
         $inviterUserId = null,
         $roleSlug = null
     ) {
-        $path = "/user_management/invitations";
+        $path = "user_management/invitations";
 
         $params = [
             "email" => $email,
@@ -421,7 +421,7 @@ class UserManagement
      */
     public function getInvitation($invitationId)
     {
-        $path = "/user_management/invitations/{$invitationId}";
+        $path = "user_management/invitations/{$invitationId}";
 
         $response = Client::request(
             Client::METHOD_GET,
@@ -445,7 +445,7 @@ class UserManagement
      */
     public function findInvitationByToken($invitationToken)
     {
-        $path = "/user_management/invitations/by_token/{$invitationToken}";
+        $path = "user_management/invitations/by_token/{$invitationToken}";
 
         $response = Client::request(
             Client::METHOD_GET,
@@ -483,7 +483,7 @@ class UserManagement
         $after = null,
         $order = null
     ) {
-        $path = "/user_management/invitations";
+        $path = "user_management/invitations";
 
         $params = [
             "email" => $email,
@@ -524,7 +524,7 @@ class UserManagement
      */
     public function revokeInvitation($invitationId)
     {
-        $path = "/user_management/invitations/{$invitationId}/revoke";
+        $path = "user_management/invitations/{$invitationId}/revoke";
 
         $response = Client::request(
             Client::METHOD_POST,
@@ -923,7 +923,7 @@ class UserManagement
      */
     public function getEmailVerification($emailVerificationId)
     {
-        $path = "/user_management/email_verification/{$emailVerificationId}";
+        $path = "user_management/email_verification/{$emailVerificationId}";
 
         $response = Client::request(
             Client::METHOD_GET,
@@ -988,7 +988,7 @@ class UserManagement
      */
     public function getPasswordReset($passwordResetId)
     {
-        $path = "/user_management/password_reset/{$passwordResetId}";
+        $path = "user_management/password_reset/{$passwordResetId}";
 
         $response = Client::request(
             Client::METHOD_GET,
@@ -1013,7 +1013,7 @@ class UserManagement
     public function createPasswordReset(
         $email,
     ) {
-        $path = "/user_management/password_reset";
+        $path = "user_management/password_reset";
 
         $params = [
             "email" => $email
@@ -1093,7 +1093,7 @@ class UserManagement
      */
     public function getMagicAuth($magicAuthId)
     {
-        $path = "/user_management/magic_auth/{$magicAuthId}";
+        $path = "user_management/magic_auth/{$magicAuthId}";
 
         $response = Client::request(
             Client::METHOD_GET,
@@ -1120,7 +1120,7 @@ class UserManagement
         $email,
         $invitationToken = null,
     ) {
-        $path = "/user_management/magic_auth";
+        $path = "user_management/magic_auth";
 
         $params = [
             "email" => $email,
@@ -1149,7 +1149,7 @@ class UserManagement
      */
     public function sendMagicAuthCode($email)
     {
-        $path = "/user_management/magic_auth/send";
+        $path = "user_management/magic_auth/send";
 
         $params = [
             "email" => $email,

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -495,7 +495,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public function testGetEmailVerification()
     {
         $emailVerificationId = "email_verification_01E4ZCR3C56J083X43JQXF3JK5";
-        $path = "/user_management/email_verification/{$emailVerificationId}";
+        $path = "user_management/email_verification/{$emailVerificationId}";
 
         $result = $this->emailVerificationResponseFixture();
 
@@ -567,7 +567,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public function testGetPasswordReset()
     {
         $passwordResetId = "password_reset_01E4ZCR3C56J083X43JQXF3JK5";
-        $path = "/user_management/password_reset/{$passwordResetId}";
+        $path = "user_management/password_reset/{$passwordResetId}";
 
         $result = $this->passwordResetResponseFixture();
 
@@ -589,7 +589,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testCreatePasswordReset()
     {
-        $path = "/user_management/password_reset";
+        $path = "user_management/password_reset";
 
         $result = $this->passwordResetResponseFixture();
 
@@ -723,7 +723,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public function testGetMagicAuth()
     {
         $magicAuthId = "magic_auth_01E4ZCR3C56J083X43JQXF3JK5";
-        $path = "/user_management/magic_auth/{$magicAuthId}";
+        $path = "user_management/magic_auth/{$magicAuthId}";
 
         $result = $this->magicAuthResponseFixture();
 
@@ -745,7 +745,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateMagicAuth()
     {
-        $path = "/user_management/magic_auth";
+        $path = "user_management/magic_auth";
 
         $result = $this->magicAuthResponseFixture();
 
@@ -774,7 +774,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     private function testSendMagicAuthCode()
     {
-        $path = "/user_management/magic_auth/send";
+        $path = "user_management/magic_auth/send";
 
         $params = [
             "email" => "test@test.com"
@@ -1045,7 +1045,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testSendInvitation()
     {
-        $path = "/user_management/invitations";
+        $path = "user_management/invitations";
 
         $result = $this->invitationResponseFixture();
 
@@ -1082,7 +1082,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public function testGetInvitation()
     {
         $invitationId = "invitation_01E4ZCR3C56J083X43JQXF3JK5";
-        $path = "/user_management/invitations/{$invitationId}";
+        $path = "user_management/invitations/{$invitationId}";
 
         $result = $this->invitationResponseFixture();
 
@@ -1105,7 +1105,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public function testFindInvitationByToken()
     {
         $invitationToken = "Z1uX3RbwcIl5fIGJJJCXXisdI";
-        $path = "/user_management/invitations/by_token/{$invitationToken}";
+        $path = "user_management/invitations/by_token/{$invitationToken}";
 
         $result = $this->invitationResponseFixture();
 
@@ -1127,7 +1127,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testListInvitations()
     {
-        $path = "/user_management/invitations";
+        $path = "user_management/invitations";
 
         $result = $this->invitationListResponseFixture();
 
@@ -1158,7 +1158,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
     public function testRevokeInvitation()
     {
         $invitationId = "invitation_01E4ZCR3C56J083X43JQXF3JK5";
-        $path = "/user_management/invitations/{$invitationId}/revoke";
+        $path = "user_management/invitations/{$invitationId}/revoke";
 
         $result = $this->invitationResponseFixture();
 


### PR DESCRIPTION
## Description
An issue comes up when calling the getMagicAuth function: 
{
    "message": "Cannot GET //user_management/magic_auth/magic_auth_XXXXXXXXXXXXXXXX",
    "error": "Not Found"
}

The crux of the issue is that there's a double slash getting appended to the front of the route after the base URL. In looking at the base URL, it includes an ending slash '/' and the path for the API call also includes a leading slash so I believe this to be the cause of the discrepancy. 