### PR TITLE
Bump Version to 4.11.1

### DIFF
--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS;
 final class Version
 {
     public const SDK_IDENTIFIER = "WorkOS PHP";
-    public const SDK_VERSION = '4.11.0';
+    public const SDK_VERSION = '4.11.1';
 }


### PR DESCRIPTION
## Description
Bumps version to 4.11.1 (bugfix, no new functionality)
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
