### PR TITLE
Add `organizationId` parameter to `authenticateWithRefreshToken`

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -796,6 +796,7 @@ class UserManagement
      * @param string $refreshToken The refresh token used to obtain a new access token
      * @param string|null $ipAddress The IP address of the request from the user who is attempting to authenticate.
      * @param string|null $userAgent The user agent of the request from the user who is attempting to authenticate.
+     * @param string|null $organizationId The user agent of the request from the user who is attempting to authenticate.
      *
      * @throws Exception\WorkOSException
      *
@@ -805,12 +806,14 @@ class UserManagement
         $clientId,
         $refreshToken,
         $ipAddress = null,
-        $userAgent = null
+        $userAgent = null,
+        $organizationId = null
     ) {
         $path = "user_management/authenticate";
         $params = [
             "client_id" => $clientId,
             "refresh_token" => $refreshToken,
+            "organization_id" => $organizationId,
             "ip_address" => $ipAddress,
             "user_agent" => $userAgent,
             "grant_type" => "refresh_token",

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -377,6 +377,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $params = [
             "client_id" => "project_0123456",
             "refresh_token" => "Xw0NsCVXMBf7svAoIoKBmkpEK",
+            "organization_id" => null,
             "ip_address" => null,
             "user_agent" => null,
             "grant_type" => "refresh_token",


### PR DESCRIPTION
## Description

Adds support for the optional `organization_id` parameter for the `refresh_token` grant type.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
