### PR TITLE
Add widgets get token API support

### DIFF
--- a/lib/Resource/WidgetScope.php
+++ b/lib/Resource/WidgetScope.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class WidgetScope
+ *
+ * Widget scopes supported through the WorkOS Widgets API.
+ */
+class WidgetScope
+{
+    public const UsersTableManage = "widgets:users-table:manage";
+}

--- a/lib/Resource/WidgetTokenResponse.php
+++ b/lib/Resource/WidgetTokenResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class WidgetTokenResponse.
+ *
+ * @property string $token
+ */
+class WidgetTokenResponse extends BaseWorkOSResource
+{
+    public const RESOURCE_TYPE = "widget_token_response";
+
+    public const RESOURCE_ATTRIBUTES = [
+        "token"
+    ];
+
+    public const RESPONSE_TO_RESOURCE_KEY = [
+        "token" => "token"
+    ];
+}

--- a/lib/Widgets.php
+++ b/lib/Widgets.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WorkOS;
+
+/**
+ * Class Widgets.
+ *
+ * This class facilitates the use of the WorkOS Widgets API.
+ */
+class Widgets
+{
+    /**
+     * Generate a widget token scoped to an organization and user.
+     *
+     * @param string $organization_id An Organization identifier.
+     * @param string $user_id An AuthKit user identifier.
+     * @param WidgetScope[] $scopes The scopes to mint the widget token with. Possible values are ["widgets:users-table:manage"].
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return \WorkOS\Resource\WidgetTokenResponse
+     */
+    public function getToken($organization_id, $user_id, $scopes)
+    {
+        $getTokenPath = "widgets/token";
+        $params = [
+            "organization_id" => $organization_id,
+            "user_id" => $user_id,
+            "scopes" => $scopes,
+        ];
+
+        $response = Client::request(Client::METHOD_POST, $getTokenPath, null, $params, true);
+
+        return Resource\WidgetTokenResponse::constructFromResponse($response);
+    }
+}

--- a/tests/WorkOS/WidgetsTest.php
+++ b/tests/WorkOS/WidgetsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace WorkOS;
+
+class WidgetsTest extends \PHPUnit\Framework\TestCase
+{
+    use TestHelper {
+        setUp as protected traitSetUp;
+    }
+
+    protected function setUp(): void
+    {
+        $this->traitSetUp();
+
+        $this->withApiKey();
+        $this->ap = new Widgets();
+    }
+
+    public function testGenerateLinkSSO()
+    {
+        $getTokenPath = "widgets/token";
+
+        $result = $this->generateWidgetTokenFixture();
+
+        $params = [
+            "organization_id" => "org_01EHZNVPK3SFK441A1RGBFSHRT",
+            "user_id" => "user_01EHZNVPK3SFK441A1RGBFSHRT",
+            "scopes" => ["widgets:users-table:manage"]
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $getTokenPath,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $expectation = "abc123456";
+
+        $response = $this->ap->getToken("org_01EHZNVPK3SFK441A1RGBFSHRT", "user_01EHZNVPK3SFK441A1RGBFSHRT", ["widgets:users-table:manage"]);
+        $this->assertSame($expectation, $response->token);
+    }
+
+    // Fixtures
+
+    private function generateWidgetTokenFixture()
+    {
+        return json_encode([
+            "token" => "abc123456"
+        ]);
+    }
+}


### PR DESCRIPTION
## Description
Add widgets get token API support.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
