### PR TITLE
Add GET /organization/:orgId/roles support

### DIFF
--- a/lib/Organizations.php
+++ b/lib/Organizations.php
@@ -175,4 +175,34 @@ class Organizations
 
         return $response;
     }
+
+    /**
+     * List roles for an organization.
+     *
+     * @param string $organizationId WorkOS organization ID to fetch roles for
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return array An array containing the following:
+     *      array \WorkOS\Resource\Role instances
+     */
+    public function listOrganizationRoles($organizationId)
+    {
+        $organizationRolesPath = "organizations/{$organizationId}/roles";
+
+        $response = Client::request(
+            Client::METHOD_GET,
+            $organizationRolesPath,
+            null,
+            null,
+            true
+        );
+
+        $roles = [];
+        foreach ($response["data"] as $responseData) {
+            \array_push($roles, Resource\Role::constructFromResponse($responseData));
+        }
+
+        return [$roles];
+    }
 }

--- a/lib/Resource/Role.php
+++ b/lib/Resource/Role.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class Role.
+ */
+
+class Role extends BaseWorkOSResource
+{
+    public const RESOURCE_TYPE = "role";
+
+    public const RESOURCE_ATTRIBUTES = [
+        "id",
+        "name",
+        "slug",
+        "description",
+        "type",
+        "created_at",
+        "updated_at"
+    ];
+
+    public const RESPONSE_TO_RESOURCE_KEY = [
+        "id" => "id",
+        "name" => "name",
+        "slug" => "slug",
+        "description" => "description",
+        "type" => "type",
+        "created_at" => "created_at",
+        "updated_at" => "updated_at"
+    ];
+}

--- a/tests/WorkOS/OrganizationsTest.php
+++ b/tests/WorkOS/OrganizationsTest.php
@@ -161,6 +161,27 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($organization, $organizations[0]->toArray());
     }
 
+    public function testListOrganizationRoles()
+    {
+        $organizationRolesPath = "organizations/org_01EHQMYV6MBK39QC5PZXHY59C3/roles";
+
+        $result = $this->organizationRolesResponseFixture();
+
+        $this->mockRequest(
+            Client::METHOD_GET,
+            $organizationRolesPath,
+            null,
+            null,
+            true,
+            $result
+        );
+
+        $role = $this->roleFixture();
+
+        list($roles) = $this->organizations->listOrganizationRoles("org_01EHQMYV6MBK39QC5PZXHY59C3");
+        $this->assertSame($role, $roles[0]->toArray());
+    }
+
     // Fixtures
 
     private function createOrganizationResponseFixture()
@@ -245,6 +266,58 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
                     "domain" => "example.com"
                 ]
             ]
+        ];
+    }
+
+    private function organizationRolesResponseFixture()
+    {
+        return json_encode([
+            "object" => "list",
+            "data" => [
+                [
+                    "object" => "role",
+                    "id" => "role_01EHQMYV6MBK39QC5PZXHY59C2",
+                    "name" => "Admin",
+                    "slug" => "admin",
+                    "description" => "Admin role",
+                    "type" => "EnvironmentRole",
+                    "created_at" => "2024-01-01T00:00:00.000Z",
+                    "updated_at" => "2024-01-01T00:00:00.000Z"
+                ],
+                [
+                    "object" => "role",
+                    "id" => "role_01EHQMYV6MBK39QC5PZXHY59C3",
+                    "name" => "Member",
+                    "slug" => "member",
+                    "description" => "Member role",
+                    "type" => "EnvironmentRole",
+                    "created_at" => "2024-01-01T00:00:00.000Z",
+                    "updated_at" => "2024-01-01T00:00:00.000Z"
+                ],
+                [
+                    "object" => "role",
+                    "id" => "role_01EHQMYV6MBK39QC5PZXHY59C4",
+                    "name" => "Org. Member",
+                    "slug" => "org-member",
+                    "description" => "Organization member role",
+                    "type" => "OrganizationRole",
+                    "created_at" => "2024-01-01T00:00:00.000Z",
+                    "updated_at" => "2024-01-01T00:00:00.000Z"
+                ],
+            ],
+        ]);
+    }
+
+    private function roleFixture()
+    {
+        return [
+            "id" => "role_01EHQMYV6MBK39QC5PZXHY59C2",
+            "name" => "Admin",
+            "slug" => "admin",
+            "description" => "Admin role",
+            "type" => "EnvironmentRole",
+            "created_at" => "2024-01-01T00:00:00.000Z",
+            "updated_at" => "2024-01-01T00:00:00.000Z"
         ];
     }
 }


### PR DESCRIPTION
## Description
Add GET /organization/:orgId/roles support.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
