### PR TITLE
Add `return_to` option to `getLogoutUrl`

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -1201,17 +1201,21 @@ class UserManagement
      * Returns the logout URL to end a user's session and redirect to your home page.
      *
      * @param string $sessionId The session ID of the user.
+     * @param string $return_to The URL to redirect to after the user logs out.
      *
      * @return string
      */
-    public function getLogoutUrl(string $sessionId)
+    public function getLogoutUrl(string $sessionId, string $return_to = null)
     {
         if (!isset($sessionId) || empty($sessionId)) {
             throw new Exception\UnexpectedValueException("sessionId must not be empty");
         }
 
-        $baseUrl = WorkOS::getApiBaseUrl();
+        $params = [ "session_id" => $sessionId ];
+        if ($return_to) {
+            $params["return_to"] = $return_to;
+        }
 
-        return "{$baseUrl}user_management/sessions/logout?session_id={$sessionId}";
+        return Client::generateUrl("user_management/sessions/logout", $params);
     }
 }

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -1217,6 +1217,16 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($result, $expected);
     }
 
+    public function testGetLogoutUrlWithReturnTo()
+    {
+        $result = $this->userManagement->getLogoutUrl("session_123", return_to: "https://your-app.com");
+
+        $this->assertSame(
+            $result,
+            "https://api.workos.com/user_management/sessions/logout?session_id=session_123&return_to=https%3A%2F%2Fyour-app.com"
+        );
+    }
+
     public function testGetLogoutUrlException()
     {
         $result = "sessionId must not be empty";


### PR DESCRIPTION
## Description

Adds a new optional `return_to` option to `getLogoutUrl` to support the upcoming Logout URIs feature.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
