### PR TITLE
add lastSignInAt to user

### DIFF
--- a/lib/Resource/User.php
+++ b/lib/Resource/User.php
@@ -17,6 +17,7 @@ class User extends BaseWorkOSResource
         "lastName",
         "emailVerified",
         "profilePictureUrl",
+        "lastSignInAt",
         "createdAt",
         "updatedAt"
     ];
@@ -29,6 +30,7 @@ class User extends BaseWorkOSResource
         "last_name" => "lastName",
         "email_verified" => "emailVerified",
         "profile_picture_url" => "profilePictureUrl",
+        "last_sign_in_at" => "lastSignInAt",
         "created_at" => "createdAt",
         "updated_at" => "updatedAt"
     ];

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -1417,6 +1417,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
                 "last_name" => "Alabaster",
                 "email_verified" => true,
                 "profile_picture_url" => "https://example.com/photo.jpg",
+                "last_sign_in_at" => "2021-06-25T19:07:33.155Z",
                 "created_at" => "2021-06-25T19:07:33.155Z",
                 "updated_at" => "2021-06-25T19:07:33.155Z"
             ]
@@ -1434,6 +1435,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
                 "last_name" => "Alabaster",
                 "email_verified" => true,
                 "profile_picture_url" => "https://example.com/photo.jpg",
+                "last_sign_in_at" => "2021-06-25T19:07:33.155Z",
                 "created_at" => "2021-06-25T19:07:33.155Z",
                 "updated_at" => "2021-06-25T19:07:33.155Z"
             ],
@@ -1456,6 +1458,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
                 "last_name" => "Alabaster",
                 "email_verified" => true,
                 'profile_picture_url' => 'https://example.com/photo.jpg',
+                "last_sign_in_at" => "2021-06-25T19:07:33.155Z",
                 "created_at" => "2021-06-25T19:07:33.155Z",
                 "updated_at" => "2021-06-25T19:07:33.155Z"
             ]
@@ -1472,6 +1475,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "last_name" => "Alabaster",
             "email_verified" => true,
             'profile_picture_url' => 'https://example.com/photo.jpg',
+            "last_sign_in_at" => "2021-06-25T19:07:33.155Z",
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z"
         ]);
@@ -1579,6 +1583,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "last_name" => "Alabaster",
             "email_verified" => true,
             "profile_picture_url" => "https://example.com/photo.jpg",
+            "last_sign_in_at" => "2021-06-25T19:07:33.155Z",
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z"
         ]);
@@ -1596,6 +1601,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
                     "last_name" => "Alabaster",
                     "email_verified" => true,
                     "profile_picture_url" => "https://example.com/photo.jpg",
+                    "last_sign_in_at" => "2021-06-25T19:07:33.155Z",
                     "created_at" => "2021-06-25T19:07:33.155Z",
                     "updated_at" => "2021-06-25T19:07:33.155Z"
                 ]
@@ -1625,6 +1631,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
             "lastName" => "Alabaster",
             "emailVerified" => true,
             "profilePictureUrl" => "https://example.com/photo.jpg",
+            "lastSignInAt" => "2021-06-25T19:07:33.155Z",
             "createdAt" => "2021-06-25T19:07:33.155Z",
             "updatedAt" => "2021-06-25T19:07:33.155Z"
         ];
@@ -1641,6 +1648,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
                 "last_name" => "Alabaster",
                 "email_verified" => true,
                 "profile_picture_url" => "https://example.com/photo.jpg",
+                "last_sign_in_at" => "2021-06-25T19:07:33.155Z",
                 "created_at" => "2021-06-25T19:07:33.155Z",
                 "updated_at" => "2021-06-25T19:07:33.155Z"
             ],


### PR DESCRIPTION
## Description
https://linear.app/workos/issue/AUTH-4180/update-workos-php-sdk-for-last-sign-in-at

Adds `lastSignInAt` to user

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```
If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

docs PR: https://github.com/workos/workos/pull/35170
