### PR TITLE
Improve PHPdoc types

### DIFF
--- a/lib/AuditLogs.php
+++ b/lib/AuditLogs.php
@@ -37,7 +37,7 @@ class AuditLogs
      *
      * @throws Exception\WorkOSException
      *
-     * @return  \WorkOS\Resource\AuditLogCreateEventStatus
+     * @return  Resource\AuditLogCreateEventStatus
      */
 
     public function createEvent($organizationId, $event, $idempotencyKey = null)

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -44,7 +44,7 @@ class Client
      * @throws \WorkOS\Exception\NotFoundException if a 404 status code is returned
      * @throws \WorkOS\Exception\BadRequestException if a 400 status code is returned
      *
-     * @return string JSON
+     * @return array<string, mixed>
      */
     public static function request($method, $path, $headers = null, $params = null, $withAuth = false)
     {

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -44,7 +44,7 @@ class Client
      * @throws \WorkOS\Exception\NotFoundException if a 404 status code is returned
      * @throws \WorkOS\Exception\BadRequestException if a 400 status code is returned
      *
-     * @return \WorkOS\Resource\Response
+     * @return Resource\Response
      */
     public static function request($method, $path, $headers = null, $params = null, $withAuth = false)
     {

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -44,7 +44,7 @@ class Client
      * @throws \WorkOS\Exception\NotFoundException if a 404 status code is returned
      * @throws \WorkOS\Exception\BadRequestException if a 400 status code is returned
      *
-     * @return Resource\Response
+     * @return string JSON
      */
     public static function request($method, $path, $headers = null, $params = null, $withAuth = false)
     {

--- a/lib/DirectorySync.php
+++ b/lib/DirectorySync.php
@@ -20,14 +20,11 @@ class DirectorySync
      * @param null|string $before Directory ID to look before
      * @param null|string $after Directory ID to look after
      * @param null|string $organizationId Unique ID for an organization
-     * @param \WorkOS\Resource\Order $order The Order in which to paginate records
+     * @param Resource\Order $order The Order in which to paginate records
      *
      * @throws Exception\WorkOSException
      *
-     * @return array An array containing the following:
-     *      null|string Directory ID to use as before cursor
-     *      null|string Directory ID to use as after cursor
-     *      array \WorkOS\Resource\Directory instances
+     * @return array{?string, ?string, Resource\Directory[]} An array containing the Directory ID to use as before and after cursor, and an array of Directory instances
      */
     public function listDirectories(
         $domain = null,
@@ -74,14 +71,11 @@ class DirectorySync
      * @param int $limit Maximum number of records to return
      * @param null|string $before Directory Group ID to look before
      * @param null|string $after Directory Group ID to look after
-     * @param \WorkOS\Resource\Order $order The Order in which to paginate records
+     * @param Resource\Order $order The Order in which to paginate records
      *
      * @throws Exception\WorkOSException
      *
-     * @return array An array containing the following:
-     *      null|string Directory Group ID to use as before cursor
-     *      null|string Directory Group ID to use as after cursor
-     *      array \WorkOS\Resource\DirectoryGroup instances
+     * @return array{?string, ?string, Resource\DirectoryGroup[]} An array containing the Directory Group ID to use as before and after cursor, and an array of Directory Group instances
      */
     public function listGroups(
         $directory = null,
@@ -130,7 +124,7 @@ class DirectorySync
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\DirectoryGroup
+     * @return Resource\DirectoryGroup
      */
     public function getGroup($directoryGroup)
     {
@@ -155,14 +149,11 @@ class DirectorySync
      * @param int $limit Maximum number of records to return
      * @param null|string $before Directory User ID to look before
      * @param null|string $after Directory User ID to look after
-     * @param \WorkOS\Resource\Order $order The Order in which to paginate records
+     * @param Resource\Order $order The Order in which to paginate records
+     *
+     * @return array{?string, ?string, Resource\DirectoryUser[]} An array containing the Directory User ID to use as before and after cursor, and an array of Directory User instances
      *
      * @throws Exception\WorkOSException
-     *
-     * @return array An array containing the following:
-     *      null|string Directory User ID to use as before cursor
-     *      null|string Directory User ID to use as after cursor
-     *      array \WorkOS\Resource\DirectoryUser instances
      */
     public function listUsers(
         $directory = null,
@@ -211,7 +202,7 @@ class DirectorySync
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\DirectoryUser
+     * @return Resource\DirectoryUser
      */
     public function getUser($directoryUser)
     {
@@ -235,7 +226,7 @@ class DirectorySync
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Response
+     * @return Resource\Response
      */
     public function deleteDirectory($directory)
     {
@@ -259,7 +250,7 @@ class DirectorySync
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Directory
+     * @return Resource\Directory
      */
     public function getDirectory($directory)
     {

--- a/lib/Exception/BaseRequestException.php
+++ b/lib/Exception/BaseRequestException.php
@@ -2,6 +2,8 @@
 
 namespace WorkOS\Exception;
 
+use WorkOS\Resource\Response;
+
 /**
  * Class BaseRequestException.
  *
@@ -20,7 +22,7 @@ class BaseRequestException extends \Exception implements WorkOSException
     /**
      * BaseRequestException constructor.
      *
-     * @param \WorkOS\Resource\Response $response
+     * @param Response $response
      * @param null|string $message Exception message
      */
     public function __construct($response, $message = null)

--- a/lib/MFA.php
+++ b/lib/MFA.php
@@ -48,11 +48,11 @@ class MFA
         }
 
         $params = [
-        "type" => $type,
-        "totp_issuer" => $totpIssuer,
-        "totp_user" => $totpUser,
-        "phone_number" => $phoneNumber
-    ];
+            "type" => $type,
+            "totp_issuer" => $totpIssuer,
+            "totp_user" => $totpUser,
+            "phone_number" => $phoneNumber
+        ];
         $response = Client::request(
             Client::METHOD_POST,
             $enrollPath,
@@ -74,6 +74,8 @@ class MFA
      *
      * @param string $authenticationFactorId - ID of the authentication factor
      * @param string|null $smsTemplate - Optional parameter to customize the message for sms type factors. Must include "{{code}}" if used.
+     *
+     * @return Resource\AuthenticationChallengeTotp|Resource\AuthenticationChallengeSms
      */
     public function challengeFactor(
         $authenticationFactorId,
@@ -197,6 +199,8 @@ class MFA
      * Deletes a Factor.
      *
      * @param string $authenticationFactorId - WorkOS Factor ID
+     *
+     * @return Resource\Response
      *
      * @throws Exception\WorkOSException
      */

--- a/lib/Organizations.php
+++ b/lib/Organizations.php
@@ -19,14 +19,11 @@ class Organizations
      * @param int $limit Maximum number of records to return
      * @param null|string $before Organization ID to look before
      * @param null|string $after Organization ID to look after
-     * @param \WorkOS\Resource\Order $order The Order in which to paginate records
+     * @param Resource\Order $order The Order in which to paginate records
+     *
+     * @return array{?string, ?string, Resource\Organization[]} An array containing the Organization ID to use as before and after cursor, and an array of Organization instances
      *
      * @throws Exception\WorkOSException
-     *
-     * @return array An array containing the following:
-     *      null|string Organization ID to use as before cursor
-     *      null|string Organization ID to use as after cursor
-     *      array \WorkOS\Resource\Organization instances
      */
     public function listOrganizations(
         $domains = null,
@@ -73,7 +70,7 @@ class Organizations
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Organization
+     * @return Resource\Organization
      */
     public function createOrganization($name, $domains = null, $allowProfilesOutsideOrganization = null, $idempotencyKey = null, $domain_data = null)
     {
@@ -141,7 +138,7 @@ class Organizations
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Organization
+     * @return Resource\Organization
      */
     public function getOrganization($organization)
     {
@@ -159,7 +156,7 @@ class Organizations
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Response
+     * @return Resource\Response
      */
     public function deleteOrganization($organization)
     {
@@ -183,8 +180,7 @@ class Organizations
      *
      * @throws Exception\WorkOSException
      *
-     * @return array An array containing the following:
-     *      array \WorkOS\Resource\Role instances
+     * @return array{0: Resource\Role[]} An array containing the list of Role instances
      */
     public function listOrganizationRoles($organizationId)
     {

--- a/lib/Passwordless.php
+++ b/lib/Passwordless.php
@@ -13,15 +13,15 @@ class Passwordless
      * Generates a passwordless session.
      *
      * @param string $email Email address of the user that the session is to be created for
-     * @param null|string $redirectURI URI to direct the user to user to upon authenticating through the passwordless link
+     * @param null|string $redirectUri URI to direct the user to user to upon authenticating through the passwordless link
      * @param null|string $state Encoded string used to manage application state
      * @param string $type The only supported ConnectionType at the time of this writing is MagicLink
-     * @param $connection the unique WorkOS connection_ID
-     * @param $expiresIn The number of seconds the Passwordless Session should live before expiring.
+     * @param string $connection Unique WorkOS connection_ID
+     * @param int $expiresIn Number of seconds the Passwordless Session should live before expiring.
      *
      * @throws Exception\WorkOSException
      *
-     * @return  \WorkOS\Resource\PasswordlessSession
+     * @return  Resource\PasswordlessSession
      */
     public function createSession($email, $redirectUri, $state, $type, $connection, $expiresIn)
     {
@@ -56,11 +56,11 @@ class Passwordless
     /**
      * Send a passwordless link via email from WorkOS.
      *
-     * @param \WorkOS\Resource\PasswordlessSession $session Passwordless session generated through Passwordless->createSession
+     * @param Resource\PasswordlessSession $session Passwordless session generated through Passwordless->createSession
      *
      * @throws Exception\WorkOSException
      *
-     * @return boolean true
+     * @return true
      */
     public function sendSession($session)
     {

--- a/lib/Portal.php
+++ b/lib/Portal.php
@@ -21,7 +21,7 @@ class Portal
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\PortalLink
+     * @return Resource\PortalLink
      */
     public function generateLink($organization, $intent, $returnUrl = null, $successUrl = null)
     {

--- a/lib/RequestClient/CurlRequestClient.php
+++ b/lib/RequestClient/CurlRequestClient.php
@@ -2,6 +2,9 @@
 
 namespace WorkOS\RequestClient;
 
+use WorkOS\Client;
+use WorkOS\Exception\GenericException;
+
 /**
  * Class CurlRequestClient.
  */
@@ -13,7 +16,7 @@ class CurlRequestClient implements RequestClientInterface
      * @param null|array $headers Headers for request
      * @param null|array $params Associative array that'll be passed as query parameters or form data
      *
-     * @throws \WorkOS\Exception\GenericException if a client level exception is encountered
+     * @throws GenericException if a client level exception is encountered
      *
      * @return array An array composed of the result string, response headers and status code
      */
@@ -26,14 +29,14 @@ class CurlRequestClient implements RequestClientInterface
         $opts = [\CURLOPT_RETURNTRANSFER => 1];
 
         switch ($method) {
-            case \WorkOS\Client::METHOD_GET:
+            case Client::METHOD_GET:
                 if (!empty($params)) {
                     $url .= "?" . http_build_query($params);
                 }
 
                 break;
 
-            case \WorkOS\CLIENT::METHOD_POST:
+            case Client::METHOD_POST:
                 \array_push($headers, "Content-Type: application/json");
 
                 $opts[\CURLOPT_POST] = 1;
@@ -44,7 +47,7 @@ class CurlRequestClient implements RequestClientInterface
 
                 break;
 
-            case \WorkOS\CLIENT::METHOD_DELETE:
+            case Client::METHOD_DELETE:
 
                 $opts[\CURLOPT_CUSTOMREQUEST] = 'DELETE';
 
@@ -55,7 +58,7 @@ class CurlRequestClient implements RequestClientInterface
 
                 break;
 
-            case \WorkOS\CLIENT::METHOD_PUT:
+            case Client::METHOD_PUT:
 
                 \array_push($headers, "Content-Type: application/json");
 
@@ -103,7 +106,7 @@ class CurlRequestClient implements RequestClientInterface
             $msg = \curl_error($curl);
             \curl_close($curl);
 
-            throw new \WorkOS\Exception\GenericException($msg, ["curlErrno" => $errno]);
+            throw new GenericException($msg, ["curlErrno" => $errno]);
         } else {
             // Unsure how versions of cURL and PHP correlate so using the legacy
             // reference for getting the last response code

--- a/lib/RequestClient/RequestClientInterface.php
+++ b/lib/RequestClient/RequestClientInterface.php
@@ -2,6 +2,8 @@
 
 namespace WorkOS\RequestClient;
 
+use WorkOS\Exception\GenericException;
+
 /**
  * Interface RequestClientInterface.
  */
@@ -13,7 +15,7 @@ interface RequestClientInterface
      * @param null|array $headers Headers for request
      * @param null|array $params Associative array that'll be passed as query parameters or form data
      *
-     * @throws \WorkOS\Exception\GenericException if a client level exception is encountered
+     * @throws GenericException if a client level exception is encountered
      *
      * @return array An array composed of the result string, response headers and status code
      */

--- a/lib/Resource/AuthenticationFactorAndChallengeTotp.php
+++ b/lib/Resource/AuthenticationFactorAndChallengeTotp.php
@@ -25,6 +25,7 @@ class AuthenticationFactorAndChallengeTotp extends BaseWorkOSResource
         $instance = parent::constructFromResponse($response);
         $instance->values["authenticationFactor"] = AuthenticationFactorTotp::constructFromResponse($response["authentication_factor"]);
         $instance->values["authenticationChallenge"] = AuthenticationChallengeTotp::constructFromResponse($response["authentication_challenge"]);
+
         return $instance;
     }
 }

--- a/lib/Resource/BaseWorkOSResource.php
+++ b/lib/Resource/BaseWorkOSResource.php
@@ -21,9 +21,9 @@ class BaseWorkOSResource
     /**
      * Creates a Resource from a Response.
      *
-     * @param \WorkOS\Resource\Response $response
+     * @param Response $response
      *
-     * @return \WorkOS\Resource\*
+     * @return static
      */
     public static function constructFromResponse($response)
     {

--- a/lib/Resource/BaseWorkOSResource.php
+++ b/lib/Resource/BaseWorkOSResource.php
@@ -21,7 +21,7 @@ class BaseWorkOSResource
     /**
      * Creates a Resource from a Response.
      *
-     * @param Response $response
+     * @param array<string, mixed> $response
      *
      * @return static
      */

--- a/lib/Resource/Webhook.php
+++ b/lib/Resource/Webhook.php
@@ -14,12 +14,13 @@ class Webhook
      *
      * @param  $payload
      *
-     * @return \WorkOS\Resource\Webhook
+     * @return Webhook
      */
     public static function constructFromPayload($payload)
     {
         $jsonPayload = json_decode($payload);
         $object = (object) $jsonPayload;
+
         return $object;
     }
 }

--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -98,7 +98,7 @@ class SSO
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\ProfileAndToken
+     * @return Resource\ProfileAndToken
      */
     public function getProfileAndToken($code)
     {
@@ -123,7 +123,7 @@ class SSO
      *
      * @throws Exception\GenericException
      *
-     * @return \WorkOS\Resource\Profile
+     * @return Resource\Profile
      */
     public function getProfile($accessToken)
     {
@@ -160,7 +160,7 @@ class SSO
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Response
+     * @return Resource\Response
      */
     public function deleteConnection($connection)
     {
@@ -184,7 +184,7 @@ class SSO
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Connection
+     * @return Resource\Connection
      */
     public function getConnection($connection)
     {
@@ -212,14 +212,11 @@ class SSO
      * @param int $limit Maximum number of records to return
      * @param null|string $before Connection ID to look before
      * @param null|string $after Connection ID to look after
-     * @param \WorkOS\Resource\Order $order The Order in which to paginate records
+     * @param Resource\Order $order The Order in which to paginate records
+     *
+     * @return array{?string, ?string, Resource\Connection[]} An array containing the Directory Connection ID to use as before and after cursor, and an array of Connection instances
      *
      * @throws Exception\WorkOSException
-     *
-     * @return array An array containing the following:
-     *      null|string Connection ID to use as before cursor
-     *      null|string Connection ID to use as after cursor
-     *      array \WorkOS\Resource\Connection instances
      */
     public function listConnections(
         $domain = null,

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -29,7 +29,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\User
+     * @return Resource\User
      */
     public function createUser($email, $password = null, $firstName = null, $lastName = null, $emailVerified = null, $passwordHash = null, $passwordHashType = null)
     {
@@ -56,7 +56,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\User
+     * @return Resource\User
      */
     public function getUser($userId)
     {
@@ -80,7 +80,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\User
+     * @return Resource\User
      */
     public function updateUser(
         $userId,
@@ -115,14 +115,11 @@ class UserManagement
      * @param int $limit Maximum number of records to return
      * @param null|string $before User ID to look before
      * @param null|string $after User ID to look after
-     * @param \WorkOS\Resource\Order $order The Order in which to paginate records
+     * @param Resource\Order $order The Order in which to paginate records
+     *
+     * @return array{?string, ?string, Resource\User[]} An array containing the Directory User ID to use as before and after cursor, and an array of User instances
      *
      * @throws Exception\WorkOSException
-     *
-     * @return array An array containing the following:
-     *      null|string User ID to use as before cursor
-     *      null|string User ID to use as after cursor
-     *      array \WorkOS\Resource\User instances
      */
     public function listUsers(
         $email = null,
@@ -167,7 +164,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Response
+     * @return Resource\Response
      */
     public function deleteUser($userId)
     {
@@ -186,7 +183,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Response
+     * @return Resource\OrganizationMembership
      */
     public function createOrganizationMembership($userId, $organizationId)
     {
@@ -215,7 +212,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Response
+     * @return Resource\OrganizationMembership
      */
     public function getOrganizationMembership($organizationMembershipId)
     {
@@ -239,7 +236,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Response
+     * @return Resource\Response
      */
     public function deleteOrganizationMembership($organizationMembershipId)
     {
@@ -264,7 +261,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\User
+     * @return Resource\OrganizationMembership
      */
     public function updateOrganizationMembership($organizationMembershipId, $role_slug)
     {
@@ -294,14 +291,11 @@ class UserManagement
      * @param int $limit Maximum number of records to return
      * @param string|null $before Organization Membership ID to look before
      * @param string|null $after Organization Membership ID to look after
-     * @param \WorkOS\Resource\Order $order The Order in which to paginate records
+     * @param Resource\Order $order The Order in which to paginate records
      *
      * @throws Exception\WorkOSException
      *
-     * @return array An array containing the following:
-     *      string|null Organization Membership ID to use as before cursor
-     *      string|null Organization Membership ID to use as after cursor
-     *      array \WorkOS\Resource\OrganizationMembership instances
+     * @return array{?string, ?string, Resource\OrganizationMembership[]} An array containing the Organization Membership ID to use as before and after cursor, and a list of Organization Memberships instances
      */
     public function listOrganizationMemberships(
         $userId = null,
@@ -359,7 +353,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Response
+     * @return Resource\OrganizationMembership
      */
     public function deactivateOrganizationMembership($organizationMembershipId)
     {
@@ -383,7 +377,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Response
+     * @return Resource\OrganizationMembership
      */
     public function reactivateOrganizationMembership($organizationMembershipId)
     {
@@ -411,7 +405,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Invitation
+     * @return Resource\Invitation
      */
     public function sendInvitation(
         $email,
@@ -448,7 +442,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Invitation
+     * @return Resource\Invitation
      */
     public function getInvitation($invitationId)
     {
@@ -472,7 +466,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Invitation
+     * @return Resource\Invitation
      */
     public function findInvitationByToken($invitationToken)
     {
@@ -497,14 +491,11 @@ class UserManagement
      * @param int $limit Maximum number of records to return
      * @param string|null $before Organization Membership ID to look before
      * @param string|null $after Organization Membership ID to look after
-     * @param \WorkOS\Resource\Order $order The Order in which to paginate records
+     * @param Resource\Order $order The Order in which to paginate records
      *
      * @throws Exception\WorkOSException
      *
-     * @return array An array containing the following:
-     *      string|null Invitation ID to use as before cursor
-     *      string|null Invitation ID to use as after cursor
-     *      array \WorkOS\Resource\Invitation instances
+     * @return array{?string, ?string, Resource\Invitation[]} An array containing the Invitation ID to use as before and after cursor, and a list of Invitations instances
      */
     public function listInvitations(
         $email = null,
@@ -551,7 +542,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Invitation
+     * @return Resource\Invitation
      */
     public function revokeInvitation($invitationId)
     {
@@ -669,7 +660,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\AuthenticationResponse
+     * @return Resource\AuthenticationResponse
      */
     public function authenticateWithPassword($clientId, $email, $password, $ipAddress = null, $userAgent = null)
     {
@@ -700,7 +691,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\AuthenticationResponse
+     * @return Resource\AuthenticationResponse
      */
     public function authenticateWithSelectedOrganization(
         $clientId,
@@ -736,7 +727,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\AuthenticationResponse
+     * @return Resource\AuthenticationResponse
      */
     public function authenticateWithCode($clientId, $code, $ipAddress = null, $userAgent = null)
     {
@@ -766,7 +757,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\AuthenticationResponse
+     * @return Resource\AuthenticationResponse
      */
     public function authenticateWithEmailVerification($clientId, $code, $pendingAuthenticationToken, $ipAddress = null, $userAgent = null)
     {
@@ -797,7 +788,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\AuthenticationResponse
+     * @return Resource\AuthenticationResponse
      */
 
     public function authenticateWithMagicAuth(
@@ -833,7 +824,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\AuthenticationResponse
+     * @return Resource\AuthenticationResponse
      */
     public function authenticateWithRefreshToken(
         $clientId,
@@ -870,7 +861,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\AuthenticationResponse
+     * @return Resource\AuthenticationResponse
      */
     public function authenticateWithTotp(
         $clientId,
@@ -907,7 +898,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\UserResponse
+     * @return Resource\AuthenticationFactorAndChallengeTotp
      */
     public function enrollAuthFactor($userId, $type, $totpIssuer = null, $totpUser = null)
     {
@@ -931,7 +922,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return array $authFactors An array containing the user's authentication factors as \WorkOS\Resource\UserAuthenticationFactorTotp instances
+     * @return Resource\UserAuthenticationFactorTotp[] $authFactors A list of user's authentication factors
      */
     public function listAuthFactors($userId)
     {
@@ -955,7 +946,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\EmailVerification
+     * @return Resource\EmailVerification
      */
     public function getEmailVerification($emailVerificationId)
     {
@@ -979,7 +970,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\User
+     * @return Resource\UserResponse
      */
     public function sendVerificationEmail($userId)
     {
@@ -998,7 +989,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\UserResponse
+     * @return Resource\UserResponse
      */
     public function verifyEmail($userId, $code)
     {
@@ -1020,7 +1011,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\PasswordReset
+     * @return Resource\PasswordReset
      */
     public function getPasswordReset($passwordResetId)
     {
@@ -1044,7 +1035,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\PasswordReset
+     * @return Resource\PasswordReset
      */
     public function createPasswordReset(
         $email,
@@ -1074,7 +1065,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Response
+     * @return Resource\Response
      */
     public function sendPasswordResetEmail($email, $passwordResetUrl)
     {
@@ -1102,7 +1093,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\UserResponse
+     * @return Resource\UserResponse
      */
     public function resetPassword($token, $newPassword)
     {
@@ -1125,7 +1116,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\MagicAuth
+     * @return Resource\MagicAuth
      */
     public function getMagicAuth($magicAuthId)
     {
@@ -1150,7 +1141,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\MagicAuth
+     * @return Resource\MagicAuth
      */
     public function createMagicAuth(
         $email,
@@ -1181,7 +1172,7 @@ class UserManagement
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\Response
+     * @return Resource\Response
      */
     public function sendMagicAuthCode($email)
     {

--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -7,38 +7,37 @@ namespace WorkOS;
  *
  * This class includes functions for users to pass in a webhook header/body and receive
  * the webhook ID, body, and event type if the webhook is valid/secure otherwise an error
- * indictating the issue.
+ * indicating the issue.
  */
-
 class Webhook
 {
-    /** Initializes an Event object from a JSON payload
-     * @param \WorkOS\Resource\Webhook
+    /**
+     * Initializes an Event object from a JSON payload
      *
-     * @return boolean true
+     * @return string
      */
-
     public function constructEvent($sigHeader, $payload, $secret, $tolerance)
     {
         $eventResult = $this->verifyHeader($sigHeader, $payload, $secret, $tolerance);
 
-        if ($eventResult == "pass"):
+        if ($eventResult == "pass") {
             return Resource\Webhook::constructFromPayload($payload);
-        else:
+        } else {
             return $eventResult;
-        endif;
+        }
     }
 
     /**
-     *  verifyHeader verifies the header returned from WorkOS contains a valid timestamp
-     *  no older than 3 minutes, and computes the signature.
-     * @param $sigheader is the WorkOS header containing v1 signature and timestamp
-     * @param $payload is the body of the webhook
-     * @param $secret is the webhook secret from the WorkOS dashboard
-     * @param $tolerance is the number of seconds old the webhook can be before it's invalid
-     * @return boolean true
+     * Verifies the header returned from WorkOS contains a valid timestamp
+     * no older than 3 minutes, and computes the signature.
+     *
+     * @param string $sigHeader WorkOS header containing v1 signature and timestamp
+     * @param string $payload Body of the webhook
+     * @param string $secret Webhook secret from the WorkOS dashboard
+     * @param int $tolerance Number of seconds old the webhook can be before it's invalid
+     *
+     * @return bool true
      */
-
     public function verifyHeader($sigHeader, $payload, $secret, $tolerance)
     {
         $timestamp = (int)$this->getTimeStamp($sigHeader);
@@ -48,42 +47,46 @@ class Webhook
         $signedPayload = $timestamp . "." . $payload;
         $expectedSignature = hash_hmac("sha256", $signedPayload, $secret, false);
 
-        if (empty($timestamp)):
+        if (empty($timestamp)) {
             return "No Timestamp available";
-        elseif (empty($signature)):
+        } elseif (empty($signature)) {
             return "No signature hash found with expected scheme v1";
-        elseif ($timestamp < $currentTime - $tolerance):
+        } elseif ($timestamp < $currentTime - $tolerance) {
             return "Timestamp outside of tolerance";
-        elseif ($signature != $expectedSignature):
+        } elseif ($signature != $expectedSignature) {
             return "Constructed signature " . $expectedSignature . "Does not match WorkOS Header Signature " . $signature;
-        else:
+        } else {
             return "pass";
-        endif;
+        }
     }
 
     /**
-    *  Splits WorkOS header's two values and pulls out timestamp value and returns it
-    * @param $sigheader is the WorkOS header containing v1 signature and timestamp
-    * @return $timestamp
-    */
-
+     * Splits WorkOS header's two values and pulls out timestamp value and returns it
+     *
+     * @param string $sigHeader WorkOS header containing v1 signature and timestamp
+     *
+     * @return $timestamp
+     */
     public function getTimeStamp($sigHeader)
     {
         $workosHeadersSplit = explode(",", $sigHeader, 2);
         $timestamp = substr($workosHeadersSplit[0], 2);
+
         return $timestamp;
     }
 
     /**
-    * splits WorkOS headers two values and pulls out the signature value and returns it
-    * @param $sigheader is the WorkOS header containing v1 signature and timestamp
-    * @return $signature
-    */
-
+     * Splits WorkOS headers two values and pulls out the signature value and returns it
+     *
+     * @param string $sigHeader WorkOS header containing v1 signature and timestamp
+     *
+     * @return string
+     */
     public function getSignature($sigHeader)
     {
         $workosHeadersSplit = explode(",", $sigHeader, 2);
         $signature = substr($workosHeadersSplit[1], 4);
+
         return $signature;
     }
 }

--- a/lib/Widgets.php
+++ b/lib/Widgets.php
@@ -14,11 +14,11 @@ class Widgets
      *
      * @param string $organization_id An Organization identifier.
      * @param string $user_id An AuthKit user identifier.
-     * @param WidgetScope[] $scopes The scopes to mint the widget token with. Possible values are ["widgets:users-table:manage"].
+     * @param Resource\WidgetScope[] $scopes The scopes to mint the widget token with. Possible values are ["widgets:users-table:manage"].
      *
      * @throws Exception\WorkOSException
      *
-     * @return \WorkOS\Resource\WidgetTokenResponse
+     * @return Resource\WidgetTokenResponse
      */
     public function getToken($organization_id, $user_id, $scopes)
     {

--- a/tests/WorkOS/AuditLogsTest.php
+++ b/tests/WorkOS/AuditLogsTest.php
@@ -2,7 +2,9 @@
 
 namespace WorkOS;
 
-class AuditLogsTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class AuditLogsTest extends TestCase
 {
     use TestHelper {
         setUp as protected traitSetUp;

--- a/tests/WorkOS/ClientTest.php
+++ b/tests/WorkOS/ClientTest.php
@@ -5,7 +5,7 @@ namespace WorkOS;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-class ClientTest extends \PHPUnit\Framework\TestCase
+class ClientTest extends TestCase
 {
     use TestHelper;
 

--- a/tests/WorkOS/DirectorySyncTest.php
+++ b/tests/WorkOS/DirectorySyncTest.php
@@ -2,7 +2,9 @@
 
 namespace WorkOS;
 
-class DirectorySyncTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class DirectorySyncTest extends TestCase
 {
     use TestHelper {
         setUp as traitSetUp;

--- a/tests/WorkOS/MFATest.php
+++ b/tests/WorkOS/MFATest.php
@@ -2,7 +2,9 @@
 
 namespace WorkOS;
 
-class MFATest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class MFATest extends TestCase
 {
     use TestHelper {
         setUp as traitSetUp;

--- a/tests/WorkOS/OrganizationsTest.php
+++ b/tests/WorkOS/OrganizationsTest.php
@@ -2,7 +2,9 @@
 
 namespace WorkOS;
 
-class OrganizationsTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class OrganizationsTest extends TestCase
 {
     use TestHelper {
         setUp as protected traitSetUp;

--- a/tests/WorkOS/PasswordlessTest.php
+++ b/tests/WorkOS/PasswordlessTest.php
@@ -2,7 +2,9 @@
 
 namespace WorkOS;
 
-class PasswordlessTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class PasswordlessTest extends TestCase
 {
     use TestHelper {
         setUp as traitSetUp;

--- a/tests/WorkOS/PortalTest.php
+++ b/tests/WorkOS/PortalTest.php
@@ -2,7 +2,9 @@
 
 namespace WorkOS;
 
-class PortalTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class PortalTest extends TestCase
 {
     use TestHelper {
         setUp as protected traitSetUp;

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use WorkOS\Resource\RoleResponse;
 
-class SSOTest extends \PHPUnit\Framework\TestCase
+class SSOTest extends TestCase
 {
     use TestHelper {
         setUp as traitSetUp;

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -5,7 +5,7 @@ namespace WorkOS;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-class UserManagementTest extends \PHPUnit\Framework\TestCase
+class UserManagementTest extends TestCase
 {
     use TestHelper {
         setUp as traitSetUp;

--- a/tests/WorkOS/WebhookTest.php
+++ b/tests/WorkOS/WebhookTest.php
@@ -2,7 +2,9 @@
 
 namespace WorkOS;
 
-class WebhookTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class WebhookTest extends TestCase
 {
     use TestHelper {
         setUp as protected traitSetUp;

--- a/tests/WorkOS/WidgetsTest.php
+++ b/tests/WorkOS/WidgetsTest.php
@@ -2,7 +2,9 @@
 
 namespace WorkOS;
 
-class WidgetsTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class WidgetsTest extends TestCase
 {
     use TestHelper {
         setUp as protected traitSetUp;


### PR DESCRIPTION
## Description

Hello,
Looking at the source, I found some PHPdoc that can be improved. The main fix is the return type of `constructFromResponse()` ([comment](https://github.com/workos/workos-php/pull/260#discussion_r1970498040)).

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
