### PR TITLE
Add email standard attribute to DirectoryUser and mark deprecated standard attributes

### DIFF
--- a/lib/Resource/DirectoryUser.php
+++ b/lib/Resource/DirectoryUser.php
@@ -19,7 +19,7 @@ class DirectoryUser extends BaseWorkOSResource
          * @deprecated Will be removed in a future major version.
          * Enable the `emails` custom attribute in dashboard and pull from customAttributes instead.
          * See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
-         */ 
+         */
         "emails",
         /**
          * @deprecated Will be removed in a future major version.

--- a/lib/Resource/DirectoryUser.php
+++ b/lib/Resource/DirectoryUser.php
@@ -16,20 +16,20 @@ class DirectoryUser extends BaseWorkOSResource
         "firstName",
         "email",
         /**
-         * @deprecated Will be removed in a future major version.
+         * [Deprecated] Will be removed in a future major version.
          * Enable the `emails` custom attribute in dashboard and pull from customAttributes instead.
          * See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
          */
         "emails",
         /**
-         * @deprecated Will be removed in a future major version.
+         * [Deprecated] Will be removed in a future major version.
          * Enable the `username` custom attribute in dashboard and pull from customAttributes instead.
          * See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
          */
         "username",
         "lastName",
         /**
-         * @deprecated Will be removed in a future major version.
+         * [Deprecated] Will be removed in a future major version.
          * Enable the `job_title` custom attribute in dashboard and pull from customAttributes instead.
          * See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
          */
@@ -59,7 +59,7 @@ class DirectoryUser extends BaseWorkOSResource
     ];
 
     /**
-     * @deprecated Use `email` instead.
+     * [Deprecated] Use `email` instead.
      */
     public function primaryEmail()
     {

--- a/lib/Resource/DirectoryUser.php
+++ b/lib/Resource/DirectoryUser.php
@@ -14,9 +14,25 @@ class DirectoryUser extends BaseWorkOSResource
         "rawAttributes",
         "customAttributes",
         "firstName",
+        "email",
+        /**
+         * @deprecated Will be removed in a future major version.
+         * Enable the `emails` custom attribute in dashboard and pull from customAttributes instead.
+         * See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
+         */ 
         "emails",
+        /**
+         * @deprecated Will be removed in a future major version.
+         * Enable the `username` custom attribute in dashboard and pull from customAttributes instead.
+         * See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
+         */
         "username",
         "lastName",
+        /**
+         * @deprecated Will be removed in a future major version.
+         * Enable the `job_title` custom attribute in dashboard and pull from customAttributes instead.
+         * See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
+         */
         "jobTitle",
         "state",
         "idpId",
@@ -30,6 +46,7 @@ class DirectoryUser extends BaseWorkOSResource
         "raw_attributes" => "rawAttributes",
         "custom_attributes" => "customAttributes",
         "first_name" => "firstName",
+        "email" => "email",
         "emails" => "emails",
         "username" => "username",
         "last_name" => "lastName",
@@ -41,6 +58,9 @@ class DirectoryUser extends BaseWorkOSResource
         "organization_id" => "organizationId"
     ];
 
+    /**
+     * @deprecated Use `email` instead.
+     */
     public function primaryEmail()
     {
         $response = $this;

--- a/tests/WorkOS/DirectorySyncTest.php
+++ b/tests/WorkOS/DirectorySyncTest.php
@@ -352,6 +352,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
                     "organization_id" => "org_123",
                     "idp_id" => null,
                     "groups" => null,
+                    "email" => "yoon@seri.com",
                     "emails" => [
                         [
                             "primary" => true,
@@ -407,6 +408,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
             "organization_id" => "org_123",
             "idp_id" => null,
             "groups" => null,
+            "email" => "yoon@seri.com",
             "emails" => [
                 [
                     "primary" => true,
@@ -460,6 +462,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
             "organization_id" => "org_123",
             "idp_id" => null,
             "groups" => null,
+            "email" => null,
             "emails" => [],
             "raw_attributes" => [
                 "schemas" => ["urn:scim:schemas:core:1.0"],
@@ -530,6 +533,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
                 "fullName" => "Yoon Seri"
             ],
             "firstName" => "Yoon",
+            "email" => "yoon@seri.com",
             "emails" => [
                 [
                     "primary" => true,


### PR DESCRIPTION
## Description
Add email standard attribute to DirectoryUser and mark deprecated standard attributes.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
