### PR TITLE
Fix phpdoc

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -44,7 +44,7 @@ class Client
      * @throws \WorkOS\Exception\NotFoundException if a 404 status code is returned
      * @throws \WorkOS\Exception\BadRequestException if a 400 status code is returned
      *
-     * @return \WorkOS\Resource\Response
+     * @return array
      */
     public static function request($method, $path, $headers = null, $params = null, $withAuth = false)
     {

--- a/lib/Resource/BaseWorkOSResource.php
+++ b/lib/Resource/BaseWorkOSResource.php
@@ -21,9 +21,9 @@ class BaseWorkOSResource
     /**
      * Creates a Resource from a Response.
      *
-     * @param \WorkOS\Resource\Response $response
+     * @param array $response
      *
-     * @return \WorkOS\Resource\*
+     * @return static
      */
     public static function constructFromResponse($response)
     {


### PR DESCRIPTION
## Description

Hi @nicknisi

Current phpdoc is wrong and lead to misuage of method or static analysis errors.

Client::request returns an array
and `constructFromResponse` accepts an array.

a new patch release with this would be great

## Documentation

No need