### PR TITLE
Make workos-php compatible with PHP 7.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - 'master'
+      - "main"
   pull_request: {}
 
 defaults:
@@ -15,21 +15,34 @@ jobs:
     name: Test PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        php: ['8.1', '8.2', '8.3']
+        php: ["7.3", "7.4", "8.1", "8.2", "8.3"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: 'composer'
+          tools: "composer"
+
+      - name: Cache Composer packages
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-${{ matrix.php }}-
 
       - name: Install dependencies
         run: |
-          composer install
+          composer install --prefer-dist --no-progress --no-interaction
 
       - name: Lint and formatting
+        if: >-
+          matrix.php == '7.4' || 
+          matrix.php == '8.1' || 
+          matrix.php == '8.2' || 
+          matrix.php == '8.3'
         run: |
           composer run-script format-check
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.15|^3.6",
-    "phpunit/phpunit": "^10"
+    "phpunit/phpunit": "^9"
   },
   "autoload": {
     "psr-4": {

--- a/lib/Resource/RoleResponse.php
+++ b/lib/Resource/RoleResponse.php
@@ -9,7 +9,7 @@ namespace WorkOS\Resource;
  */
 class RoleResponse
 {
-    public string $slug;
+    public $slug;
 
     public function __construct(string $slug)
     {

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -89,7 +89,7 @@ class UserManagement
         $emailVerified = null,
         $password = null,
         $passwordHash = null,
-        $passwordHashType = null,
+        $passwordHashType = null
     ) {
         $path = "user_management/users/{$userId}";
 
@@ -310,7 +310,7 @@ class UserManagement
         $limit = self::DEFAULT_PAGE_SIZE,
         $before = null,
         $after = null,
-        $order = null,
+        $order = null
     ) {
         $path = "user_management/organization_memberships";
 
@@ -1047,7 +1047,7 @@ class UserManagement
      * @return \WorkOS\Resource\PasswordReset
      */
     public function createPasswordReset(
-        $email,
+        $email
     ) {
         $path = "user_management/password_reset";
 
@@ -1154,7 +1154,7 @@ class UserManagement
      */
     public function createMagicAuth(
         $email,
-        $invitationToken = null,
+        $invitationToken = null
     ) {
         $path = "user_management/magic_auth";
 

--- a/tests/WorkOS/ClientTest.php
+++ b/tests/WorkOS/ClientTest.php
@@ -9,7 +9,9 @@ class ClientTest extends \PHPUnit\Framework\TestCase
 {
     use TestHelper;
 
-    #[DataProvider('requestExceptionTestProvider')]
+    /**
+     * @dataProvider requestExceptionTestProvider
+     */
     public function testClientThrowsRequestExceptions($statusCode, $exceptionClass)
     {
         $this->withApiKeyAndClientId();
@@ -31,7 +33,9 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         Client::request(Client::METHOD_GET, $path);
     }
 
-    #[DataProvider('requestExceptionTestProvider')]
+    /**
+     * @dataProvider requestExceptionTestProvider
+     */
     public function testClientThrowsRequestExceptionsIncludeRequestId($statusCode, $exceptionClass)
     {
         $this->withApiKeyAndClientId();
@@ -60,7 +64,9 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $this->fail("Expected exception of type " . $exceptionClass . " not thrown.");
     }
 
-    #[DataProvider('requestExceptionTestProvider')]
+    /**
+     * @dataProvider requestExceptionTestProvider
+     */
     public function testClientThrowsRequestExceptionsWithBadMessage($statusCode, $exceptionClass)
     {
         $this->withApiKeyAndClientId();
@@ -87,7 +93,9 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    #[DataProvider('requestExceptionTestProvider')]
+    /**
+     * @dataProvider requestExceptionTestProvider
+     */
     public function testClientThrowsRequestExceptionsWithMessageAndCode($statusCode, $exceptionClass)
     {
         $this->withApiKeyAndClientId();
@@ -116,7 +124,9 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    #[DataProvider('requestExceptionTestProvider')]
+    /**
+     * @dataProvider requestExceptionTestProvider
+     */
     public function testClientThrowsRequestExceptionsWithErrorAndErrorDescription($statusCode, $exceptionClass)
     {
         $this->withApiKeyAndClientId();
@@ -145,7 +155,9 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    #[DataProvider('requestExceptionTestProvider')]
+    /**
+     * @dataProvider requestExceptionTestProvider
+     */
     public function testClientThrowsRequestExceptionsWithErrors($statusCode, $exceptionClass)
     {
         $this->withApiKeyAndClientId();

--- a/tests/WorkOS/OrganizationsTest.php
+++ b/tests/WorkOS/OrganizationsTest.php
@@ -69,7 +69,10 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->organizations->createOrganization(
             "Organization Name",
-            domain_data: array(["domain" => "example.com", "state" => "verified"]),
+            null,
+            null,
+            null,
+            array(["domain" => "example.com", "state" => "verified"]),
         );
         $this->assertSame($organization, $response->toArray());
     }
@@ -101,7 +104,10 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->organizations->updateOrganization(
             "org_01EHQMYV6MBK39QC5PZXHY59C3",
-            domain_data: array(["domain" => "example.com", "state" => "verified"]),
+            null,
+            null,
+            null,
+            array(["domain" => "example.com", "state" => "verified"]),
         );
         $this->assertSame($organization, $response->toArray());
     }

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -20,7 +20,9 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         $this->sso = new SSO();
     }
 
-    #[DataProvider('authorizationUrlTestProvider')]
+    /**
+     * @dataProvider authorizationUrlTestProvider
+     */
     public function testAuthorizationURLExpectedParams(
         $domain,
         $redirectUri,

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -119,7 +119,9 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    #[DataProvider('authorizationUrlTestDataProvider')]
+    /**
+     * @dataProvider authorizationUrlTestDataProvider
+     */
     public function testAuthorizationURLExpectedParams(
         $redirectUri,
         $state,
@@ -1240,7 +1242,7 @@ class UserManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testGetLogoutUrlWithReturnTo()
     {
-        $result = $this->userManagement->getLogoutUrl("session_123", return_to: "https://your-app.com");
+        $result = $this->userManagement->getLogoutUrl("session_123", "https://your-app.com");
 
         $this->assertSame(
             $result,


### PR DESCRIPTION
## Description

This package is listed as requiring PHP >=7.3, but it seems to use some syntax introduced in PHP 8, as well as a version of PHPUnit that requires PHP 8. This pull request makes the minimal changes necessary to use this package in PHP 7.3.

https://github.com/workos/workos-php/blob/17bb8408033892cb3c0cc9e5e3fe833aeb32eec1/composer.json#L13

To test, I used the following `Dockerfile`:

```Dockerfile
FROM php:7.3.0

COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/

RUN install-php-extensions @composer

ADD . /workos-php
WORKDIR /workos-php

RUN composer install

ENTRYPOINT ["vendor/bin/phpunit"]
```

```sh
docker build . -t workos-php && docker run -it --rm workos-php
```

Strictly speaking, it wasn't necessary to update the tests and the PHPUnit version in order to use this package as a dependency on PHP 7.3. However, I wanted to run the tests to ensure that everything still worked.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
