### PR TITLE
Structured responses to webhook events

### DIFF
--- a/lib/Resource/WebhookResponse.php
+++ b/lib/Resource/WebhookResponse.php
@@ -35,16 +35,20 @@ class WebhookResponse
      * Create a new WebhookResponse instance
      *
      * @param string $type Either USER_REGISTRATION_ACTION or AUTHENTICATION_ACTION
+     * @param string $secret Webhook secret for signing the response
      * @param string $verdict Either VERDICT_ALLOW or VERDICT_DENY
      * @param string|null $errorMessage Required if verdict is VERDICT_DENY
-     * @param string|null $secret Webhook secret for signing the response
      * @return self
      * @throws \InvalidArgumentException
      */
-    public static function create($type, $verdict, $errorMessage = null, $secret = null)
+    public static function create($type, $secret, $verdict, $errorMessage = null)
     {
         if (!in_array($type, [self::USER_REGISTRATION_ACTION, self::AUTHENTICATION_ACTION])) {
             throw new \InvalidArgumentException('Invalid response type');
+        }
+
+        if (empty($secret)) {
+            throw new \InvalidArgumentException('Secret is required');
         }
 
         if (!in_array($verdict, [self::VERDICT_ALLOW, self::VERDICT_DENY])) {
@@ -69,11 +73,9 @@ class WebhookResponse
 
         $instance->payload = $payload;
 
-        if ($secret) {
-            $timestamp = $payload['timestamp'];
-            $payloadString = json_encode($payload);
-            $instance->signature = (new Webhook())->computeSignature($timestamp, $payloadString, $secret);
-        }
+        $timestamp = $payload['timestamp'];
+        $payloadString = json_encode($payload);
+        $instance->signature = (new Webhook())->computeSignature($timestamp, $payloadString, $secret);
 
         return $instance;
     }

--- a/lib/Resource/WebhookResponse.php
+++ b/lib/Resource/WebhookResponse.php
@@ -11,10 +11,10 @@ use WorkOS\Webhook;
  */
 class WebhookResponse
 {
-    const USER_REGISTRATION_ACTION = 'user_registration_action_response';
-    const AUTHENTICATION_ACTION = 'authentication_action_response';
-    const VERDICT_ALLOW = 'Allow';
-    const VERDICT_DENY = 'Deny';
+    public const USER_REGISTRATION_ACTION = 'user_registration_action_response';
+    public const AUTHENTICATION_ACTION = 'authentication_action_response';
+    public const VERDICT_ALLOW = 'Allow';
+    public const VERDICT_DENY = 'Deny';
 
     /**
      * @var string

--- a/lib/Resource/WebhookResponse.php
+++ b/lib/Resource/WebhookResponse.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace WorkOS\Resource;
+
+use WorkOS\Webhook;
+
+/**
+ * Class WebhookResponse.
+ *
+ * This class represents the response structure for WorkOS webhook actions.
+ */
+class WebhookResponse
+{
+    const USER_REGISTRATION_ACTION = 'user_registration_action_response';
+    const AUTHENTICATION_ACTION = 'authentication_action_response';
+    const VERDICT_ALLOW = 'Allow';
+    const VERDICT_DENY = 'Deny';
+
+    /**
+     * @var string
+     */
+    private $object;
+
+    /**
+     * @var array
+     */
+    private $payload;
+
+    /**
+     * @var string
+     */
+    private $signature;
+
+    /**
+     * Create a new WebhookResponse instance
+     *
+     * @param string $type Either USER_REGISTRATION_ACTION or AUTHENTICATION_ACTION
+     * @param string $verdict Either VERDICT_ALLOW or VERDICT_DENY
+     * @param string|null $errorMessage Required if verdict is VERDICT_DENY
+     * @param string|null $secret Webhook secret for signing the response
+     * @return self
+     * @throws \InvalidArgumentException
+     */
+    public static function create($type, $verdict, $errorMessage = null, $secret = null)
+    {
+        if (!in_array($type, [self::USER_REGISTRATION_ACTION, self::AUTHENTICATION_ACTION])) {
+            throw new \InvalidArgumentException('Invalid response type');
+        }
+
+        if (!in_array($verdict, [self::VERDICT_ALLOW, self::VERDICT_DENY])) {
+            throw new \InvalidArgumentException('Invalid verdict');
+        }
+
+        if ($verdict === self::VERDICT_DENY && empty($errorMessage)) {
+            throw new \InvalidArgumentException('Error message is required when verdict is Deny');
+        }
+
+        $instance = new self();
+        $instance->object = $type;
+
+        $payload = [
+            'timestamp' => time() * 1000,
+            'verdict' => $verdict
+        ];
+
+        if ($verdict === self::VERDICT_DENY) {
+            $payload['error_message'] = $errorMessage;
+        }
+
+        $instance->payload = $payload;
+
+        if ($secret) {
+            $timestamp = $payload['timestamp'];
+            $payloadString = json_encode($payload);
+            $instance->signature = (new Webhook())->computeSignature($timestamp, $payloadString, $secret);
+        }
+
+        return $instance;
+    }
+
+    /**
+     * Get the response as an array
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $response = [
+            'object' => $this->object,
+            'payload' => $this->payload
+        ];
+
+        if ($this->signature) {
+            $response['signature'] = $this->signature;
+        }
+
+        return $response;
+    }
+
+    /**
+     * Get the response as a JSON string
+     *
+     * @return string
+     */
+    public function toJson()
+    {
+        return json_encode($this->toArray());
+    }
+}

--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -44,8 +44,7 @@ class Webhook
         $signature = $this->getSignature($sigHeader);
 
         $currentTime = time();
-        $signedPayload = $timestamp . "." . $payload;
-        $expectedSignature = hash_hmac("sha256", $signedPayload, $secret, false);
+        $expectedSignature = $this->computeSignature($timestamp, $payload, $secret);
 
         if (empty($timestamp)) {
             return "No Timestamp available";
@@ -88,5 +87,19 @@ class Webhook
         $signature = substr($workosHeadersSplit[1], 4);
 
         return $signature;
+    }
+
+    /**
+     * Computes a signature for a webhook payload using the provided timestamp and secret
+     *
+     * @param  int     $timestamp  Unix timestamp to use in signature
+     * @param  string  $payload    The payload to sign
+     * @param  string  $secret     Secret key used for signing
+     * @return string  The computed HMAC SHA-256 signature
+     */
+    public function computeSignature($timestamp, $payload, $secret)
+    {
+        $signedPayload = $timestamp . '.' . $payload;
+        return hash_hmac('sha256', $signedPayload, $secret, false);
     }
 }

--- a/tests/WorkOS/Resource/WebhookResponseTest.php
+++ b/tests/WorkOS/Resource/WebhookResponseTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace WorkOS\Resource;
+
+use PHPUnit\Framework\TestCase;
+use WorkOS\TestHelper;
+
+class WebhookResponseTest extends TestCase
+{
+    use TestHelper {
+        setUp as protected traitSetUp;
+    }
+
+    /**
+     * @var string
+     */
+    protected $secret;
+
+    /**
+     * @var int
+     */
+    protected $timestamp;
+
+    protected function setUp(): void
+    {
+        $this->traitSetUp();
+        $this->withApiKey();
+
+        $this->secret = 'test_secret';
+        $this->timestamp = time() * 1000; // milliseconds
+    }
+
+    public function testCreateAllowResponse()
+    {
+        $response = WebhookResponse::create(
+            WebhookResponse::USER_REGISTRATION_ACTION,
+            WebhookResponse::VERDICT_ALLOW,
+            null,
+            $this->secret
+        );
+
+        $array = $response->toArray();
+
+        $this->assertEquals(WebhookResponse::USER_REGISTRATION_ACTION, $array['object']);
+        $this->assertArrayHasKey('payload', $array);
+        $this->assertArrayHasKey('signature', $array);
+        $this->assertEquals(WebhookResponse::VERDICT_ALLOW, $array['payload']['verdict']);
+        $this->assertArrayHasKey('timestamp', $array['payload']);
+        $this->assertArrayNotHasKey('error_message', $array['payload']);
+    }
+
+    public function testCreateDenyResponse()
+    {
+        $errorMessage = 'Registration denied due to risk assessment';
+        $response = WebhookResponse::create(
+            WebhookResponse::USER_REGISTRATION_ACTION,
+            WebhookResponse::VERDICT_DENY,
+            $errorMessage,
+            $this->secret
+        );
+
+        $array = $response->toArray();
+
+        $this->assertEquals(WebhookResponse::USER_REGISTRATION_ACTION, $array['object']);
+        $this->assertArrayHasKey('payload', $array);
+        $this->assertArrayHasKey('signature', $array);
+        $this->assertEquals(WebhookResponse::VERDICT_DENY, $array['payload']['verdict']);
+        $this->assertEquals($errorMessage, $array['payload']['error_message']);
+        $this->assertArrayHasKey('timestamp', $array['payload']);
+    }
+
+    public function testCreateAuthenticationResponse()
+    {
+        $response = WebhookResponse::create(
+            WebhookResponse::AUTHENTICATION_ACTION,
+            WebhookResponse::VERDICT_ALLOW,
+            null,
+            $this->secret
+        );
+
+        $array = $response->toArray();
+
+        $this->assertEquals(WebhookResponse::AUTHENTICATION_ACTION, $array['object']);
+        $this->assertArrayHasKey('payload', $array);
+        $this->assertArrayHasKey('signature', $array);
+    }
+
+    public function testCreateWithoutSecret()
+    {
+        $response = WebhookResponse::create(
+            WebhookResponse::USER_REGISTRATION_ACTION,
+            WebhookResponse::VERDICT_ALLOW
+        );
+
+        $array = $response->toArray();
+
+        $this->assertArrayNotHasKey('signature', $array);
+    }
+
+    public function testInvalidResponseType()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid response type');
+
+        WebhookResponse::create(
+            'invalid_type',
+            WebhookResponse::VERDICT_ALLOW
+        );
+    }
+
+    public function testInvalidVerdict()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid verdict');
+
+        WebhookResponse::create(
+            WebhookResponse::USER_REGISTRATION_ACTION,
+            'invalid_verdict'
+        );
+    }
+
+    public function testDenyWithoutErrorMessage()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Error message is required when verdict is Deny');
+
+        WebhookResponse::create(
+            WebhookResponse::USER_REGISTRATION_ACTION,
+            WebhookResponse::VERDICT_DENY
+        );
+    }
+
+    public function testToJson()
+    {
+        $response = WebhookResponse::create(
+            WebhookResponse::USER_REGISTRATION_ACTION,
+            WebhookResponse::VERDICT_ALLOW,
+            null,
+            $this->secret
+        );
+
+        $json = $response->toJson();
+        $decoded = json_decode($json, true);
+
+        $this->assertIsString($json);
+        $this->assertIsArray($decoded);
+        $this->assertEquals(WebhookResponse::USER_REGISTRATION_ACTION, $decoded['object']);
+    }
+}

--- a/tests/WorkOS/Resource/WebhookResponseTest.php
+++ b/tests/WorkOS/Resource/WebhookResponseTest.php
@@ -34,9 +34,8 @@ class WebhookResponseTest extends TestCase
     {
         $response = WebhookResponse::create(
             WebhookResponse::USER_REGISTRATION_ACTION,
-            WebhookResponse::VERDICT_ALLOW,
-            null,
-            $this->secret
+            $this->secret,
+            WebhookResponse::VERDICT_ALLOW
         );
 
         $array = $response->toArray();
@@ -54,9 +53,9 @@ class WebhookResponseTest extends TestCase
         $errorMessage = 'Registration denied due to risk assessment';
         $response = WebhookResponse::create(
             WebhookResponse::USER_REGISTRATION_ACTION,
+            $this->secret,
             WebhookResponse::VERDICT_DENY,
-            $errorMessage,
-            $this->secret
+            $errorMessage
         );
 
         $array = $response->toArray();
@@ -73,9 +72,8 @@ class WebhookResponseTest extends TestCase
     {
         $response = WebhookResponse::create(
             WebhookResponse::AUTHENTICATION_ACTION,
-            WebhookResponse::VERDICT_ALLOW,
-            null,
-            $this->secret
+            $this->secret,
+            WebhookResponse::VERDICT_ALLOW
         );
 
         $array = $response->toArray();
@@ -87,14 +85,14 @@ class WebhookResponseTest extends TestCase
 
     public function testCreateWithoutSecret()
     {
-        $response = WebhookResponse::create(
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Secret is required');
+
+        WebhookResponse::create(
             WebhookResponse::USER_REGISTRATION_ACTION,
+            '',
             WebhookResponse::VERDICT_ALLOW
         );
-
-        $array = $response->toArray();
-
-        $this->assertArrayNotHasKey('signature', $array);
     }
 
     public function testInvalidResponseType()
@@ -104,6 +102,7 @@ class WebhookResponseTest extends TestCase
 
         WebhookResponse::create(
             'invalid_type',
+            $this->secret,
             WebhookResponse::VERDICT_ALLOW
         );
     }
@@ -115,6 +114,7 @@ class WebhookResponseTest extends TestCase
 
         WebhookResponse::create(
             WebhookResponse::USER_REGISTRATION_ACTION,
+            $this->secret,
             'invalid_verdict'
         );
     }
@@ -126,6 +126,7 @@ class WebhookResponseTest extends TestCase
 
         WebhookResponse::create(
             WebhookResponse::USER_REGISTRATION_ACTION,
+            $this->secret,
             WebhookResponse::VERDICT_DENY
         );
     }
@@ -134,9 +135,8 @@ class WebhookResponseTest extends TestCase
     {
         $response = WebhookResponse::create(
             WebhookResponse::USER_REGISTRATION_ACTION,
-            WebhookResponse::VERDICT_ALLOW,
-            null,
-            $this->secret
+            $this->secret,
+            WebhookResponse::VERDICT_ALLOW
         );
 
         $json = $response->toJson();


### PR DESCRIPTION
## Description

This PR adds webhook response functionality to handle user registration and authentication actions. The implementation includes:

- Support for both "Allow" and "Deny" verdicts in webhook responses
- Support for "user_registration_action_response" and "authentication_action_response"
- Error message handling for denied verdicts
- JSON serialization support
- Validation for:
  - Response types
  - Verdict values
  - Required error messages for deny verdicts

The changes improve webhook response handling by providing a structured way to respond to webhook events.

Example code in a Laravel app: 
```php
Route::post('work-os/user-registration-action', function (Request $request) {
    $webhook = (new Webhook)->constructEvent(
        $request->headers->get('WorkOS-Signature'),
        $request->getContent(),
        config('services.workos.webhook_secret'),
        180
    );
    
    //...

    $response = WebhookResponse::create(
        WebhookResponse::USER_REGISTRATION_ACTION,
        config('services.workos.webhook_secret'),
        WebhookResponse::VERDICT_ALLOW,
    );

    return response()->json($response->toArray(), 200, ['Content-Type' => 'application/json']);
});
```

This also allows the package to calculate the signature on the user's behalf.

Before this PR, this would have been the user's code for the same thing. 👎 

```php
Route::post('work-os/user-registration-action', function (Request $request) {
    $webhook = (new Webhook)->constructEvent(
        $request->headers->get('WorkOS-Signature'),
        $request->getContent(),
        config('services.workos.webhook_secret'),
        180
    );
    
    //...

    // Create response payload
    $responsePayload = [
        'timestamp' => time() * 1000, // Convert to milliseconds to match JS Date.now()
        'verdict' => 'Allow',
    ];
    // Create the signed response
    $timestamp = $responsePayload['timestamp'];
    $payloadString = json_encode($responsePayload);
    $signedPayload = $timestamp.'.'.$payloadString;
    $signature = hash_hmac('sha256', $signedPayload, config('services.workos.webhook_secret'), false);

    $response = [
        'object' => 'user_registration_action_response',
        'payload' => $responsePayload,
        'signature' => $signature,
    ];

    return response()->json($response, 200, ['Content-Type' => 'application/json']);
});
```

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

[] Yes
