### PR TITLE
Add support for creating, getting and updating users with external_id property

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -26,12 +26,13 @@ class UserManagement
      * @param boolean|null $emailVerified A boolean declaring if the user's email has been verified.
      * @param string|null $passwordHash The hashed password to set for the user.
      * @param string|null $passwordHashType The algorithm originally used to hash the password. Valid values are `bcrypt`, `ssha`, and `firebase-scrypt`.
+     * @param string|null $externalId The external ID of the user.
      *
      * @throws Exception\WorkOSException
      *
      * @return Resource\User
      */
-    public function createUser($email, $password = null, $firstName = null, $lastName = null, $emailVerified = null, $passwordHash = null, $passwordHashType = null)
+    public function createUser($email, $password = null, $firstName = null, $lastName = null, $emailVerified = null, $passwordHash = null, $passwordHashType = null, $externalId = null)
     {
         $path = "user_management/users";
         $params = [
@@ -42,6 +43,7 @@ class UserManagement
             "email_verified" => $emailVerified,
             "password_hash" => $passwordHash,
             "password_hash_type" => $passwordHashType,
+            "external_id" => $externalId,
         ];
 
         $response = Client::request(Client::METHOD_POST, $path, null, $params, true);
@@ -68,6 +70,24 @@ class UserManagement
     }
 
     /**
+     * Get a User by external ID.
+     *
+     * @param string $externalId The external ID of the user.
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return Resource\User
+     */
+    public function getUserByExternalId($externalId)
+    {
+        $path = "user_management/users/external_id/{$externalId}";
+
+        $response = Client::request(Client::METHOD_GET, $path, null, null, true);
+
+        return Resource\User::constructFromResponse($response);
+    }
+
+    /**
      * Update a User
      *
      * @param string $userId The unique ID of the user.
@@ -77,6 +97,7 @@ class UserManagement
      * @param string|null $password The password to set for the user.
      * @param string|null $passwordHash The hashed password to set for the user.
      * @param string|null $passwordHashType The algorithm originally used to hash the password. Valid values are `bcrypt`, `ssha`, and `firebase-scrypt`.
+     * @param string|null $externalId The external ID of the user.
      *
      * @throws Exception\WorkOSException
      *
@@ -89,7 +110,8 @@ class UserManagement
         $emailVerified = null,
         $password = null,
         $passwordHash = null,
-        $passwordHashType = null
+        $passwordHashType = null,
+        $externalId = null
     ) {
         $path = "user_management/users/{$userId}";
 
@@ -100,6 +122,7 @@ class UserManagement
             "password" => $password,
             "password_hash" => $passwordHash,
             "password_hash_type" => $passwordHashType,
+            "external_id" => $externalId,
         ];
 
         $response = Client::request(Client::METHOD_PUT, $path, null, $params, true);


### PR DESCRIPTION
## Description

This PR adds support for creating a user with an external_id property, the option to get a user by their external_id, and the ability to update the external_id property for a user.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
