### PR TITLE
Add UserIdentityProvider and UserIdentityProviderType classes

### DIFF
--- a/lib/Resource/UserIdentityProvider.php
+++ b/lib/Resource/UserIdentityProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class UserIdentityProvider.
+ */
+class UserIdentityProvider extends BaseWorkOSResource
+{
+    public const RESOURCE_TYPE = "user_identity_provider";
+
+    public const RESOURCE_ATTRIBUTES = [
+        "idpId",
+        "type",
+        "provider",
+    ];
+
+    public const RESPONSE_TO_RESOURCE_KEY = [
+        "idp_id" => "idpId",
+        "type" => "type",
+        "provider" => "provider",
+    ];
+
+    public static function constructFromResponse($response)
+    {
+        $instance = parent::constructFromResponse($response);
+
+        $instance->values["type"] = (string) new UserIdentityProviderType($response["type"]);
+
+        return $instance;
+    }
+}

--- a/lib/Resource/UserIdentityProviderType.php
+++ b/lib/Resource/UserIdentityProviderType.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class UserIdentityProviderType
+ *
+ * This class represents the type of user identity provider.
+ */
+class UserIdentityProviderType
+{
+    public const OAuth = 'OAuth';
+
+    private $type;
+
+    /**
+     * Constructor for UserIdentityProviderType.
+     *
+     * @param string $type The type of user identity provider.
+     */
+    public function __construct($type)
+    {
+        // Map of lowercase API response values to our standardized constants
+        $typeMap = [
+            'oauth' => self::OAuth,
+            // Add future types here in the format: 'lowercase_value' => self::ConstantName
+        ];
+
+        $lowercaseType = strtolower($type);
+
+        // Use our mapped constant if available, otherwise keep the original value
+        $this->type = isset($typeMap[$lowercaseType]) ? $typeMap[$lowercaseType] : $type;
+    }
+
+    public function __toString()
+    {
+        return $this->type;
+    }
+}

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -82,6 +82,29 @@ class UserManagement
     }
 
     /**
+     * Get User's identity providers
+     *
+     * @param string $userId The unique ID of the user.
+     *
+     * @throws Exception\WorkOSException
+     *
+     * @return Resource\UserIdentityProvider[]
+     */
+    public function getUserIdentityProviders($userId)
+    {
+        $path = "user_management/users/{$userId}/identities";
+
+        $response = Client::request(Client::METHOD_GET, $path, null, null, true);
+
+        $userIdentityProviders = [];
+        foreach ($response as $responseData) {
+            \array_push($userIdentityProviders, Resource\UserIdentityProvider::constructFromResponse($responseData));
+        }
+
+        return $userIdentityProviders;
+    }
+
+    /**
      * Get a User by external ID.
      *
      * @param string $externalId The external ID of the user.

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -8,11 +8,10 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class UserManagementTest extends TestCase
 {
-    private $userManagement;
-
     use TestHelper {
         setUp as traitSetUp;
     }
+    private $userManagement;
 
     protected function setUp(): void
     {

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -2,11 +2,14 @@
 
 namespace WorkOS;
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use WorkOS\Resource\UserIdentityProviderType;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UserManagementTest extends TestCase
 {
+    private $userManagement;
+
     use TestHelper {
         setUp as traitSetUp;
     }
@@ -1263,6 +1266,50 @@ class UserManagementTest extends TestCase
         } catch (Exception\UnexpectedValueException $e) {
             $this->assertEquals($e->getMessage(), $result);
         }
+    }
+
+    public function testGetUserIdentityProviders()
+    {
+        $userId = "user_01E4ZCR3C56J083X43JQXF3JK5";
+        $path = "user_management/users/{$userId}/identities";
+
+        $result = $this->userIdentityProvidersResponseFixture();
+
+        $this->mockRequest(
+            Client::METHOD_GET,
+            $path,
+            null,
+            null,
+            true,
+            $result
+        );
+
+        $userIdentityProviderFixture = $this->userIdentityProviderFixture();
+
+        $response = $this->userManagement->getUserIdentityProviders($userId);
+
+        $this->assertCount(1, $response);
+        $this->assertSame($userIdentityProviderFixture, $response[0]->toArray());
+    }
+
+    private function userIdentityProvidersResponseFixture()
+    {
+        return json_encode([
+            [
+                "idp_id" => "4F42ABDE-1E44-4B66-824A-5F733C037A6D",
+                "type" => "OAuth",
+                "provider" => "MicrosoftOAuth"
+            ]
+        ]);
+    }
+
+    private function userIdentityProviderFixture()
+    {
+        return [
+            "idpId" => "4F42ABDE-1E44-4B66-824A-5F733C037A6D",
+            "type" => "OAuth",
+            "provider" => "MicrosoftOAuth"
+        ];
     }
 
     //Fixtures


### PR DESCRIPTION
## Description

Add UserIdentityProvider and UserIdentityProviderType classes implement getUserIdentityProviders method in UserManagement class

- Introduced UserIdentityProvider and UserIdentityProviderType classes to represent user identity providers and their types.
- Added `getUserIdentityProviders` method in UserManagement to retrieve a user's identity providers.
- Implemented unit tests for the new functionality in UserManagementTest.

Resolves #271 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x ] Yes
```

https://workos.com/docs/reference/user-management/identity/list

`Get user identities` can be updated to have a PHP code sample now.

Request

```php
<?php

WorkOS\WorkOS::setApiKey("sk_example_123456789");

$userManagement = new WorkOS\UserManagement();

$user = $userManagement->getUserIdentityProviders("user_01E4ZCR3C56J083X43JQXF3JK5");
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
