### PR TITLE
add roleSlug for createOrgMembership and fix updateOrgMemberhship

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -241,9 +241,6 @@ class UserManagement
             $params,
             true
         );
-        if (!is_null($roleSlug) && !is_string($roleSlug)) {
-            throw new \InvalidArgumentException("roleSlug must be a string or null");
-        }
 
         return Resource\OrganizationMembership::constructFromResponse($response);
     }
@@ -321,9 +318,6 @@ class UserManagement
             $params,
             true
         );
-        if (!is_null($roleSlug) && !is_string($roleSlug)) {
-            throw new \InvalidArgumentException("roleSlug must be a string or null");
-        }
 
         return Resource\OrganizationMembership::constructFromResponse($response);
     }

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -218,18 +218,20 @@ class UserManagement
      *
      * @param string $userId User ID
      * @param string $organizationId Organization ID
+     * @param string|null $roleSlug Role Slug
      *
      * @throws Exception\WorkOSException
      *
      * @return Resource\OrganizationMembership
      */
-    public function createOrganizationMembership($userId, $organizationId)
+    public function createOrganizationMembership($userId, $organizationId, $roleSlug = null)
     {
         $path = "user_management/organization_memberships";
 
         $params = [
             "organization_id" => $organizationId,
-            "user_id" => $userId
+            "user_id" => $userId,
+            "role_slug" => $roleSlug
         ];
 
         $response = Client::request(
@@ -239,6 +241,9 @@ class UserManagement
             $params,
             true
         );
+        if (!is_null($roleSlug) && !is_string($roleSlug)) {
+            throw new \InvalidArgumentException("roleSlug must be a string or null");
+        }
 
         return Resource\OrganizationMembership::constructFromResponse($response);
     }
@@ -295,18 +300,18 @@ class UserManagement
      * Update a User organization membership.
      *
      * @param string $organizationMembershipId Organization Membership ID
-     * @param string $role_slug The unique role identifier.
+     * @param string|null $role_slug The unique role identifier.
      *
      * @throws Exception\WorkOSException
      *
      * @return Resource\OrganizationMembership
      */
-    public function updateOrganizationMembership($organizationMembershipId, $role_slug)
+    public function updateOrganizationMembership($organizationMembershipId, $roleSlug = null)
     {
         $path = "user_management/organization_memberships/{$organizationMembershipId}";
 
         $params = [
-            "role_slug" => $role_slug
+            "role_slug" => $roleSlug
         ];
 
         $response = Client::request(
@@ -316,6 +321,9 @@ class UserManagement
             $params,
             true
         );
+        if (!is_null($roleSlug) && !is_string($roleSlug)) {
+            throw new \InvalidArgumentException("roleSlug must be a string or null");
+        }
 
         return Resource\OrganizationMembership::constructFromResponse($response);
     }

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -837,13 +837,15 @@ class UserManagementTest extends TestCase
     {
         $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";
         $orgId = "org_01EHQMYV6MBK39QC5PZXHY59C3";
+        $roleSlug = "admin";
         $path = "user_management/organization_memberships";
 
         $result = $this->organizationMembershipResponseFixture();
 
         $params = [
             "organization_id" => $orgId,
-            "user_id" => $userId
+            "user_id" => $userId,
+            "role_slug" => $roleSlug
         ];
 
         $this->mockRequest(
@@ -857,7 +859,9 @@ class UserManagementTest extends TestCase
 
         $organizationMembership = $this->organizationMembershipFixture();
 
-        $response = $this->userManagement->createOrganizationMembership($userId, $orgId);
+        $response = $this->userManagement->createOrganizationMembership($userId, $orgId, $roleSlug);
+        echo "Response from Create Org:";
+        print_r($response);
         $this->assertSame($organizationMembership, $response->toArray());
     }
 

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -860,8 +860,7 @@ class UserManagementTest extends TestCase
         $organizationMembership = $this->organizationMembershipFixture();
 
         $response = $this->userManagement->createOrganizationMembership($userId, $orgId, $roleSlug);
-        echo "Response from Create Org:";
-        print_r($response);
+
         $this->assertSame($organizationMembership, $response->toArray());
     }
 


### PR DESCRIPTION
## Description
adds roleSlug param on createOrgMembership. Allows for updateOrgMembership to not require roleSlug.
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
