### PR TITLE
[Cross-SDK Sync] Add `email` to `updateUser` options

### DIFF
--- a/lib/UserManagement/UpdateUserOptions.php
+++ b/lib/UserManagement/UpdateUserOptions.php
@@ -1,0 +1,30 @@
+TARGET CODE:
+<?php
+
+namespace Lib\UserManagement;
+
+use Lib\UserManagement\Interfaces\UpdateUserOptions;
+use Lib\UserManagement\Interfaces\SerializedUpdateUserOptions;
+
+class UpdateUserOptionsSerializer
+{
+    public static function serializeUpdateUserOptions(UpdateUserOptions $options): SerializedUpdateUserOptions
+    {
+        return new SerializedUpdateUserOptions([
+            'email' => $options->getEmail(),
+            'email_verified' => $options->getEmailVerified(),
+            'first_name' => $options->getFirstName(),
+            'last_name' => $options->getLastName(),
+            'password' => $options->getPassword(),
+            'password_hash' => $options->getPasswordHash(),
+            'password_hash_type' => $options->getPasswordHashType(),
+            'external_id' => $options->getExternalId(),
+        ]);
+    }
+}
+
+NOTES:
+1. PHP does not have direct support for JavaScript's object literal syntax. Instead, we use an associative array to represent the serialized options.
+2. In PHP, we typically use getter methods to access object properties, assuming that the `UpdateUserOptions` class follows the common practice of encapsulating its properties with getter and setter methods.
+3. The `serializeUpdateUserOptions` function is made static, as it does not depend on any instance-specific data.
+4. The `SerializedUpdateUserOptions` is assumed to be a class that accepts an associative array in its constructor. If this is not the case, the implementation of this function may need to be adjusted accordingly.

--- a/lib/UserManagement/UpdateUserOptionsInterface.php
+++ b/lib/UserManagement/UpdateUserOptionsInterface.php
@@ -1,0 +1,48 @@
+TARGET CODE:
+<?php
+
+namespace lib\UserManagement;
+
+use lib\UserManagement\PasswordHashTypeInterface;
+
+interface UpdateUserOptionsInterface
+{
+    public function getUserId(): string;
+
+    public function getEmail(): ?string;
+
+    public function getFirstName(): ?string;
+
+    public function getLastName(): ?string;
+
+    public function getEmailVerified(): ?bool;
+
+    public function getPassword(): ?string;
+
+    public function getPasswordHash(): ?string;
+
+    public function getPasswordHashType(): ?PasswordHashTypeInterface;
+
+    public function getExternalId(): ?string;
+}
+
+interface SerializedUpdateUserOptionsInterface
+{
+    public function getEmail(): ?string;
+
+    public function getFirstName(): ?string;
+
+    public function getLastName(): ?string;
+
+    public function getEmailVerified(): ?bool;
+
+    public function getPassword(): ?string;
+
+    public function getPasswordHash(): ?string;
+
+    public function getPasswordHashType(): ?PasswordHashTypeInterface;
+
+    public function getExternalId(): ?string;
+}
+
+In PHP, interfaces are used to specify what methods a class must implement. In this case, the UpdateUserOptionsInterface and SerializedUpdateUserOptionsInterface interfaces are defined with getter methods for each property. The "?" before the type means that the return type can be that type or null. The PasswordHashTypeInterface is assumed to be in the same namespace and is used as a return type for getPasswordHashType() method.


### PR DESCRIPTION
# Automated Cross-SDK Sync

This PR was automatically translated from node PR #1273.

## Original Description
## Description

Adds `email` to the `userManagement.updateUser`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.


