### PR TITLE
[Cross-SDK Sync] Add `email` to `updateUser` options

### DIFF
--- a/lib/Resource/UserOptionsUpdate.php
+++ b/lib/Resource/UserOptionsUpdate.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Lib\Resource;
+
+use Lib\Interfaces\UpdateUserOptions;
+use Lib\Interfaces\SerializedUpdateUserOptions;
+
+class UserOptionsUpdate
+{
+    public static function serializeUpdateUserOptions(UpdateUserOptions $options): SerializedUpdateUserOptions
+    {
+        return [
+            'email' => $options->email,
+            'email_verified' => $options->emailVerified,
+            'first_name' => $options->firstName,
+            'last_name' => $options->lastName,
+            'password' => $options->password,
+            'password_hash' => $options->passwordHash,
+            'password_hash_type' => $options->passwordHashType,
+            'external_id' => $options->externalId,
+        ];
+    }
+}

--- a/lib/UserManagement/Interfaces/UpdateUserOptionsInterface.php
+++ b/lib/UserManagement/Interfaces/UpdateUserOptionsInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Lib\UserManagement\Interfaces;
+
+interface UpdateUserOptionsInterface
+{
+    public function getUserId(): string;
+    public function getEmail(): ?string;
+    public function getFirstName(): ?string;
+    public function getLastName(): ?string;
+    public function isEmailVerified(): ?bool;
+    public function getPassword(): ?string;
+    public function getPasswordHash(): ?string;
+    public function getPasswordHashType(): ?PasswordHashType;
+    public function getExternalId(): ?string;
+}
+
+interface SerializedUpdateUserOptionsInterface
+{
+    public function getEmail(): ?string;
+    public function getFirstName(): ?string;
+    public function getLastName(): ?string;
+    public function isEmailVerified(): ?bool;
+    public function getPassword(): ?string;
+    public function getPasswordHash(): ?string;
+    public function getPasswordHashType(): ?PasswordHashType;
+    public function getExternalId(): ?string;
+}


### PR DESCRIPTION
# Automated Cross-SDK Sync

This PR was automatically translated from node PR #1273.

## Original Description
## Description

Adds `email` to the `userManagement.updateUser`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.


