### PR TITLE
Add `permissions` attribute to Role

### DIFF
--- a/lib/Resource/Role.php
+++ b/lib/Resource/Role.php
@@ -15,6 +15,7 @@ class Role extends BaseWorkOSResource
         "name",
         "slug",
         "description",
+        "permissions",
         "type",
         "created_at",
         "updated_at"
@@ -25,6 +26,7 @@ class Role extends BaseWorkOSResource
         "name" => "name",
         "slug" => "slug",
         "description" => "description",
+        "permissions" => "permissions",
         "type" => "type",
         "created_at" => "created_at",
         "updated_at" => "updated_at"

--- a/lib/Resource/Role.php
+++ b/lib/Resource/Role.php
@@ -4,6 +4,15 @@ namespace WorkOS\Resource;
 
 /**
  * Class Role.
+ *
+ * @property string $id
+ * @property string $name
+ * @property string $slug
+ * @property string $description
+ * @property array<string> $permissions
+ * @property string $type
+ * @property string $created_at
+ * @property string $updated_at
  */
 
 class Role extends BaseWorkOSResource

--- a/tests/WorkOS/OrganizationsTest.php
+++ b/tests/WorkOS/OrganizationsTest.php
@@ -298,6 +298,7 @@ class OrganizationsTest extends TestCase
                     "name" => "Admin",
                     "slug" => "admin",
                     "description" => "Admin role",
+                    "permissions" => ["posts:read", "posts:write"],
                     "type" => "EnvironmentRole",
                     "created_at" => "2024-01-01T00:00:00.000Z",
                     "updated_at" => "2024-01-01T00:00:00.000Z"
@@ -308,6 +309,7 @@ class OrganizationsTest extends TestCase
                     "name" => "Member",
                     "slug" => "member",
                     "description" => "Member role",
+                    "permissions" => [],
                     "type" => "EnvironmentRole",
                     "created_at" => "2024-01-01T00:00:00.000Z",
                     "updated_at" => "2024-01-01T00:00:00.000Z"
@@ -318,6 +320,7 @@ class OrganizationsTest extends TestCase
                     "name" => "Org. Member",
                     "slug" => "org-member",
                     "description" => "Organization member role",
+                    "permissions" => ["posts:read"],
                     "type" => "OrganizationRole",
                     "created_at" => "2024-01-01T00:00:00.000Z",
                     "updated_at" => "2024-01-01T00:00:00.000Z"
@@ -333,6 +336,7 @@ class OrganizationsTest extends TestCase
             "name" => "Admin",
             "slug" => "admin",
             "description" => "Admin role",
+            "permissions" => ["posts:read", "posts:write"],
             "type" => "EnvironmentRole",
             "created_at" => "2024-01-01T00:00:00.000Z",
             "updated_at" => "2024-01-01T00:00:00.000Z"


### PR DESCRIPTION
## Description

Currently it not possible to use WorkOS permissions in a PHP application as the Role resource is missing the `permissions` attribute. This PR simply addresses the issue. PHPDocs have also been added to the Role class.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[✔️] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

PHP example will need updating: https://workos.com/docs/reference/roles

Expected new PHP example based on JSON example.
```php
<?php

$role = [
    "object" => "role",
    "id" => "role_01EHQMYV6MBK39QC5PZXHY59C3",
    "name" => "Member",
    "slug" => "member",
    "description" => "Access to basic resources",
    "permissions" => ["posts:read", "posts:write"],
    "type" => "EnvironmentRole",
    "created_at" => "2021-07-26T18:55:16.072Z",
    "updated_at" => "2021-07-26T18:55:16.072Z",
];
```