### PR TITLE
add support for custom scopes

### DIFF
--- a/lib/Resource/AuthenticationResponse.php
+++ b/lib/Resource/AuthenticationResponse.php
@@ -10,6 +10,7 @@ namespace WorkOS\Resource;
  * @property string $accessToken
  * @property string $refreshToken
  * @property ?Impersonator $impersonator
+ * @property ?OAuthTokens $oauthTokens
  */
 class AuthenticationResponse extends BaseWorkOSResource
 {
@@ -19,12 +20,14 @@ class AuthenticationResponse extends BaseWorkOSResource
         "impersonator",
         "accessToken",
         "refreshToken",
+        "oauthTokens",
     ];
 
     public const RESPONSE_TO_RESOURCE_KEY = [
         "organization_id" => "organizationId",
         "access_token" => "accessToken",
         "refresh_token" => "refreshToken",
+        "oauth_tokens" => "oauthTokens",
     ];
 
     public static function constructFromResponse($response)
@@ -37,6 +40,10 @@ class AuthenticationResponse extends BaseWorkOSResource
             $instance->values["impersonator"] = Impersonator::constructFromResponse(
                 $response["impersonator"]
             );
+        }
+
+        if (isset($response["oauth_tokens"])) {
+            $instance->values["oauthTokens"] = OAuthTokens::constructFromResponse($response["oauth_tokens"]);
         }
 
         return $instance;

--- a/lib/Resource/OAuthTokens.php
+++ b/lib/Resource/OAuthTokens.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class OAuthTokens.
+ *
+ * @property string      $accessToken
+ * @property string      $refreshToken
+ * @property int         $expiresAt
+ * @property array       $scopes
+ */
+class OAuthTokens extends BaseWorkOSResource
+{
+    public const RESOURCE_ATTRIBUTES = [
+        "accessToken",
+        "refreshToken",
+        "expiresAt",
+        "scopes"
+    ];
+
+    public const RESPONSE_TO_RESOURCE_KEY = [
+        "access_token" => "accessToken",
+        "refresh_token" => "refreshToken",
+        "expires_at" => "expiresAt",
+        "scopes" => "scopes"
+    ];
+
+    public static function constructFromResponse($response)
+    {
+        $instance = parent::constructFromResponse($response);
+
+        // Ensure scopes is always an array
+        if (!isset($instance->values["scopes"])) {
+            $instance->values["scopes"] = [];
+        }
+
+        return $instance;
+    }
+}

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -692,7 +692,7 @@ class UserManagement
         }
 
         if ($providerScopes && is_array($providerScopes)) {
-            $params["provider_scopes"] = implode(" ", $providerScopes);
+            $params["provider_scopes"] = implode(",", $providerScopes);
         }
 
         return Client::generateUrl($path, $params);

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -613,6 +613,7 @@ class UserManagement
      * @param null|string $domainHint DDomain hint that will be passed as a parameter to the IdP login page
      * @param null|string $loginHint Username/email hint that will be passed as a parameter to the to IdP login page
      * @param null|string $screenHint The page that the user will be redirected to when the provider is authkit
+     * @param null|array $providerScopes An array of provider-specific scopes
      *
      * @throws Exception\UnexpectedValueException
      * @throws Exception\ConfigurationException
@@ -627,7 +628,8 @@ class UserManagement
         $organizationId = null,
         $domainHint = null,
         $loginHint = null,
-        $screenHint = null
+        $screenHint = null,
+        $providerScopes = null
     ) {
         $path = "user_management/authorize";
 
@@ -687,6 +689,10 @@ class UserManagement
                 throw new Exception\UnexpectedValueException("A 'screenHint' can only be provided when the provider is 'authkit'.");
             }
             $params["screen_hint"] = $screenHint;
+        }
+
+        if ($providerScopes && is_array($providerScopes)) {
+            $params["provider_scopes"] = implode(" ", $providerScopes);
         }
 
         return Client::generateUrl($path, $params);

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -172,7 +172,7 @@ class UserManagementTest extends TestCase
         }
 
         if ($providerScopes && is_array($providerScopes)) {
-            $expectedParams["provider_scopes"] = implode(" ", $providerScopes);
+            $expectedParams["provider_scopes"] = implode(",", $providerScopes);
         }
 
         $authorizationUrl = $this->userManagement->getAuthorizationUrl(


### PR DESCRIPTION
## Description
- adds support for the `oauth_tokens` object in the authenticate API response
- adds support for the new `provider_scopes` query parameter

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
