### PR TITLE
fix(Profile): Fixed the fetching of a workos profile.

### DIFF
--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -125,21 +125,16 @@ class SSO
      *
      * @return Resource\Profile
      */
-    public function getProfile()
+    public function getProfile($accessToken)
     {
         $response = Client::request(
             Client::METHOD_GET,
             'sso/profile',
+            ["Authorization: Bearer " . $accessToken],
             null,
-            null,
-            true
         );
 
-        if (!array_key_exists('profile', $response)) {
-            throw new Exception\GenericException('The profile was not found in the response.');
-        }
-
-        return Resource\Profile::constructFromResponse($response['profile']);
+        return Resource\Profile::constructFromResponse($response);
     }
 
     /**

--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -125,32 +125,21 @@ class SSO
      *
      * @return Resource\Profile
      */
-    public function getProfile($accessToken)
+    public function getProfile()
     {
-        $getProfilePath = "sso/profile";
-
-        $params = [
-            "access_token" => $accessToken
-        ];
-
-        $method = Client::METHOD_GET;
-
-        $url = "https://api.workos.com/sso/profile";
-
-        $requestHeaders = ["Authorization: Bearer " . $accessToken];
-
-        list($result) = Client::requestClient()->request(
-            $method,
-            $url,
-            $requestHeaders,
-            null
+        $response = Client::request(
+            Client::METHOD_GET,
+            'sso/profile',
+            null,
+            null,
+            true
         );
 
-        $decodedResponse = json_decode($result, true);
+        if (!array_key_exists('profile', $response)) {
+            throw new Exception\GenericException('The profile was not found in the response.');
+        }
 
-        $profile = Resource\Profile::constructFromResponse($decodedResponse);
-
-        return $profile->json();
+        return Resource\Profile::constructFromResponse($response['profile']);
     }
 
     /**

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -115,6 +115,27 @@ class SSOTest extends TestCase
         $this->assertEquals($profileFixture, $profileAndToken->profile->toArray());
     }
 
+    public function testGetProfileReturnsProfileWithExpectedValues()
+    {
+        $path = "sso/profile";
+
+        $result = $this->profileAndTokenResponseFixture();
+
+        $this->mockRequest(
+            Client::METHOD_GET,
+            $path,
+            null,
+            null,
+            true,
+            $result
+        );
+
+        $profile = $this->sso->getProfile();
+        $profileFixture = $this->profileFixture();
+
+        $this->assertEquals($profileFixture, $profile->toArray());
+    }
+
     public function testGetConnection()
     {
         $connection = "connection_id";

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -118,19 +118,20 @@ class SSOTest extends TestCase
     public function testGetProfileReturnsProfileWithExpectedValues()
     {
         $path = "sso/profile";
+        $token = 'token';
 
-        $result = $this->profileAndTokenResponseFixture();
+        $result = $this->profileResponseFixture();
 
         $this->mockRequest(
             Client::METHOD_GET,
             $path,
+            ['Authorization: Bearer ' . $token],
             null,
-            null,
-            true,
+            false,
             $result
         );
 
-        $profile = $this->sso->getProfile();
+        $profile = $this->sso->getProfile($token);
         $profileFixture = $this->profileFixture();
 
         $this->assertEquals($profileFixture, $profile->toArray());
@@ -278,6 +279,31 @@ class SSOTest extends TestCase
                 "license" => "professional"
             ),
         ];
+    }
+
+    private function profileResponseFixture()
+    {
+        return json_encode([
+            "id" => "prof_hen",
+            "email" => "hen@papagenos.com",
+            "first_name" => "hen",
+            "last_name" => "cha",
+            "organization_id" => "org_01FG7HGMY2CZZR2FWHTEE94VF0",
+            "connection_id" => "conn_01EMH8WAK20T42N2NBMNBCYHAG",
+            "connection_type" => "GoogleOAuth",
+            "idp_id" => "randomalphanum",
+            "role" => new RoleResponse("admin"),
+            "groups" => array("Admins", "Developers"),
+            "custom_attributes" => array("license" => "professional"),
+            "raw_attributes" => array(
+                "email" => "hen@papagenos.com",
+                "first_name" => "hen",
+                "last_name" => "cha",
+                "ipd_id" => "randomalphanum",
+                "groups" => array("Admins", "Developers"),
+                "license" => "professional"
+            ),
+        ]);
     }
 
     private function connectionFixture()


### PR DESCRIPTION
The `getProfile` method was not properly implemented and tested, wrote a test scenario for that to ensure that it works properly now.

## Description

Fixed an issue because the `json` method does not exist on the Profile class.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
