### PR TITLE
fix: add explicit nullable types for PHP 8.4 compatibility

### DIFF
--- a/lib/AuditLogs.php
+++ b/lib/AuditLogs.php
@@ -33,13 +33,13 @@ class AuditLogs
      *   - **version** (int, *optional*): Event version. Required if the version is not 1.
      *   - **metadata** (array, *optional*): Additional arbitrary key-value data for the event.
      *
-     * @param string $idempotencyKey A unique key ensuring idempotency of events for 24 hours.
+     * @param null|string $idempotencyKey A unique key ensuring idempotency of events for 24 hours.
      *
      * @throws Exception\WorkOSException
      *
      * @return Resource\AuditLogCreateEventStatus
      */
-    public function createEvent($organizationId, $event, $idempotencyKey = null)
+    public function createEvent(string $organizationId, array $event, ?string $idempotencyKey = null)
     {
         $eventsPath = "audit_logs/events";
 
@@ -58,22 +58,23 @@ class AuditLogs
     }
 
     /**
-     * @param array $auditLogExportOptions Associative array containing the keys detailed below
-     * @var null|string $organizationId Description of the record.
-     * @var null|string $rangeStart ISO-8601 Timestamp of the start of Export's the date range.
-     * @var null|string $rangeEnd ISO-8601 Timestamp  of the end of Export's the date range.
-     * @var null|array $actions Actions that Audit Log Events will be filtered by.
-     * @var null|array $actors Actor names that Audit Log Events will be filtered by. @deprecated 3.3.0 Use $actorNames instead. This method will be removed in a future major version.
-     * @var null|array $targets Target types that Audit Log Events will be filtered by.
-     * @var null|array $actorNames Actor names that Audit Log Events will be filtered by.
-     * @var null|array $actorIds Actor IDs that Audit Log Events will be filtered by.
+     * Creates an export of audit log events for an organization.
+     *
+     * @param string $organizationId The unique identifier for the organization.
+     * @param string $rangeStart ISO-8601 Timestamp of the start of Export's the date range.
+     * @param string $rangeEnd ISO-8601 Timestamp  of the end of Export's the date range.
+     * @param null|array $actions Actions that Audit Log Events will be filtered by.
+     * @param null|array $actors Actor names that Audit Log Events will be filtered by. @deprecated 3.3.0 Use $actorNames instead. This method will be removed in a future major version.
+     * @param null|array $targets Target types that Audit Log Events will be filtered by.
+     * @param null|array $actorNames Actor names that Audit Log Events will be filtered by.
+     * @param null|array $actorIds Actor IDs that Audit Log Events will be filtered by.
      *
      * @throws Exception\WorkOSException
      *
      * @return Resource\AuditLogExport
      */
 
-    public function createExport($organizationId, $rangeStart, $rangeEnd, $actions = null, $actors = null, $targets = null, $actorNames = null, $actorIds = null)
+    public function createExport(string $organizationId, string $rangeStart, string $rangeEnd, ?array $actions = null, ?array $actors = null, ?array $targets = null, ?array $actorNames = null, ?array $actorIds = null)
     {
         $createExportPath = "audit_logs/exports";
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -105,7 +105,7 @@ class Client
      *
      * @return string
      */
-    public static function generateUrl($path, $params = null)
+    public static function generateUrl(string $path, ?array $params = null)
     {
         $url = WorkOS::getApiBaseUrl() . $path;
 

--- a/lib/Exception/BaseRequestException.php
+++ b/lib/Exception/BaseRequestException.php
@@ -25,7 +25,7 @@ class BaseRequestException extends \Exception implements WorkOSException
      * @param Response $response
      * @param null|string $message Exception message
      */
-    public function __construct($response, $message = null)
+    public function __construct(Response $response, ?string $message = null)
     {
         $this->response = $response;
 

--- a/lib/Exception/GenericException.php
+++ b/lib/Exception/GenericException.php
@@ -17,7 +17,7 @@ class GenericException extends \Exception implements WorkOSException
      * @param string $message Exception message
      * @param null|array $data Blob
      */
-    public function __construct($message, $data = null)
+    public function __construct(string $message, ?array $data = null)
     {
         $this->message = $message;
 

--- a/lib/Portal.php
+++ b/lib/Portal.php
@@ -23,7 +23,7 @@ class Portal
      *
      * @return Resource\PortalLink
      */
-    public function generateLink($organization, $intent, $returnUrl = null, $successUrl = null)
+    public function generateLink(string $organization, string $intent, ?string $returnUrl = null, ?string $successUrl = null)
     {
         $generateLinkPath = "portal/generate_link";
         $params = [

--- a/lib/RequestClient/CurlRequestClient.php
+++ b/lib/RequestClient/CurlRequestClient.php
@@ -20,7 +20,7 @@ class CurlRequestClient implements RequestClientInterface
      *
      * @return array An array composed of the result string, response headers and status code
      */
-    public function request($method, $url, $headers = null, $params = null)
+    public function request(string $method, string $url, ?array $headers = null, ?array $params = null)
     {
         if (empty($headers)) {
             $headers = array();

--- a/lib/RequestClient/RequestClientInterface.php
+++ b/lib/RequestClient/RequestClientInterface.php
@@ -19,5 +19,5 @@ interface RequestClientInterface
      *
      * @return array An array composed of the result string, response headers and status code
      */
-    public function request($method, $url, $headers, $params);
+    public function request(string $method, string $url, ?array $headers = null, ?array $params = null);
 }

--- a/lib/Resource/WebhookResponse.php
+++ b/lib/Resource/WebhookResponse.php
@@ -41,7 +41,7 @@ class WebhookResponse
      * @return self
      * @throws \InvalidArgumentException
      */
-    public static function create($type, $secret, $verdict, $errorMessage = null)
+    public static function create(string $type, string $secret, string $verdict, ?string $errorMessage = null)
     {
         if (!in_array($type, [self::USER_REGISTRATION_ACTION, self::AUTHENTICATION_ACTION])) {
             throw new \InvalidArgumentException('Invalid response type');

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -227,7 +227,7 @@ class UserManagement
      *
      * @return Resource\OrganizationMembership
      */
-    public function createOrganizationMembership($userId, $organizationId, $roleSlug = null)
+    public function createOrganizationMembership(string $userId, string $organizationId, ?string $roleSlug = null)
     {
         $path = "user_management/organization_memberships";
 
@@ -306,7 +306,7 @@ class UserManagement
      *
      * @return Resource\OrganizationMembership
      */
-    public function updateOrganizationMembership($organizationMembershipId, $roleSlug = null)
+    public function updateOrganizationMembership(string $organizationMembershipId, ?string $roleSlug = null)
     {
         $path = "user_management/organization_memberships/{$organizationMembershipId}";
 
@@ -711,7 +711,7 @@ class UserManagement
      *
      * @return Resource\AuthenticationResponse
      */
-    public function authenticateWithPassword($clientId, $email, $password, $ipAddress = null, $userAgent = null)
+    public function authenticateWithPassword(string $clientId, string $email, string $password, ?string $ipAddress = null, ?string $userAgent = null)
     {
         $path = "user_management/authenticate";
         $params = [
@@ -778,7 +778,7 @@ class UserManagement
      *
      * @return Resource\AuthenticationResponse
      */
-    public function authenticateWithCode($clientId, $code, $ipAddress = null, $userAgent = null)
+    public function authenticateWithCode(string $clientId, string $code, ?string $ipAddress = null, ?string $userAgent = null)
     {
         $path = "user_management/authenticate";
         $params = [
@@ -808,7 +808,7 @@ class UserManagement
      *
      * @return Resource\AuthenticationResponse
      */
-    public function authenticateWithEmailVerification($clientId, $code, $pendingAuthenticationToken, $ipAddress = null, $userAgent = null)
+    public function authenticateWithEmailVerification(string $clientId, string $code, string $pendingAuthenticationToken, ?string $ipAddress = null, ?string $userAgent = null)
     {
         $path = "user_management/authenticate";
         $params = [
@@ -949,7 +949,7 @@ class UserManagement
      *
      * @return Resource\AuthenticationFactorAndChallengeTotp
      */
-    public function enrollAuthFactor($userId, $type, $totpIssuer = null, $totpUser = null)
+    public function enrollAuthFactor(string $userId, string $type, ?string $totpIssuer = null, ?string $totpUser = null)
     {
         $path = "user_management/users/{$userId}/auth_factors";
 
@@ -1272,11 +1272,11 @@ class UserManagement
      * Returns the logout URL to end a user's session and redirect to your home page.
      *
      * @param string $sessionId The session ID of the user.
-     * @param string $return_to The URL to redirect to after the user logs out.
+     * @param null|string $return_to The URL to redirect to after the user logs out.
      *
      * @return string
      */
-    public function getLogoutUrl(string $sessionId, string $return_to = null)
+    public function getLogoutUrl(string $sessionId, ?string $return_to = null)
     {
         if (!isset($sessionId) || empty($sessionId)) {
             throw new Exception\UnexpectedValueException("sessionId must not be empty");


### PR DESCRIPTION
fix: resolve PHP 8.4 deprecation warnings for implicit nullable parameters

- Update function signatures across the codebase to use explicit nullable type declarations
- Replace implicit nullable declarations (string $param = null) with explicit ones (?string $param = null)
- Add proper type hints for all parameters that were missing them
- Update both interfaces and implementations to maintain compatibility
- Affected files: UserManagement, Client, Exception classes, AuditLogs, Portal, RequestClient, and WebhookResponse

Ensures full compatibility with PHP 8.4 and eliminates all deprecation warnings
related to "Implicitly marking parameter as nullable is deprecated" messages.

Resolves #296