### PR TITLE
Fixed deprecation notices in tests

### DIFF
--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -1272,11 +1272,11 @@ class UserManagement
      * Returns the logout URL to end a user's session and redirect to your home page.
      *
      * @param string $sessionId The session ID of the user.
-     * @param string $return_to The URL to redirect to after the user logs out.
+     * @param string|null $return_to The URL to redirect to after the user logs out.
      *
      * @return string
      */
-    public function getLogoutUrl(string $sessionId, string $return_to = null)
+    public function getLogoutUrl(string $sessionId, ?string $return_to = null)
     {
         if (!isset($sessionId) || empty($sessionId)) {
             throw new Exception\UnexpectedValueException("sessionId must not be empty");

--- a/tests/WorkOS/AuditLogsTest.php
+++ b/tests/WorkOS/AuditLogsTest.php
@@ -10,6 +10,11 @@ class AuditLogsTest extends TestCase
         setUp as protected traitSetUp;
     }
 
+    /**
+     * @var AuditLogs
+     */
+    protected $al;
+
     protected function setUp(): void
     {
         $this->traitSetUp();

--- a/tests/WorkOS/DirectorySyncTest.php
+++ b/tests/WorkOS/DirectorySyncTest.php
@@ -10,6 +10,11 @@ class DirectorySyncTest extends TestCase
         setUp as traitSetUp;
     }
 
+    /**
+     * @var DirectorySync
+     */
+    protected $ds;
+
     protected function setUp(): void
     {
         $this->traitSetUp();

--- a/tests/WorkOS/MFATest.php
+++ b/tests/WorkOS/MFATest.php
@@ -10,6 +10,11 @@ class MFATest extends TestCase
         setUp as traitSetUp;
     }
 
+    /**
+     * @var MFA
+     */
+    protected $mfa;
+
     protected function setUp(): void
     {
         $this->traitSetUp();

--- a/tests/WorkOS/OrganizationsTest.php
+++ b/tests/WorkOS/OrganizationsTest.php
@@ -10,6 +10,11 @@ class OrganizationsTest extends TestCase
         setUp as protected traitSetUp;
     }
 
+    /**
+     * @var Organizations
+     */
+    protected $organizations;
+
     protected function setUp(): void
     {
         $this->traitSetUp();

--- a/tests/WorkOS/PasswordlessTest.php
+++ b/tests/WorkOS/PasswordlessTest.php
@@ -10,6 +10,11 @@ class PasswordlessTest extends TestCase
         setUp as traitSetUp;
     }
 
+    /**
+     * @var Passwordless
+     */
+    protected $passwordless;
+
     protected function setUp(): void
     {
         $this->traitSetUp();

--- a/tests/WorkOS/PortalTest.php
+++ b/tests/WorkOS/PortalTest.php
@@ -10,6 +10,11 @@ class PortalTest extends TestCase
         setUp as protected traitSetUp;
     }
 
+    /**
+     * @var Portal
+     */
+    protected $ap;
+
     protected function setUp(): void
     {
         $this->traitSetUp();

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -12,6 +12,11 @@ class SSOTest extends TestCase
         setUp as traitSetUp;
     }
 
+    /**
+     * @var SSO
+     */
+    protected $sso;
+
     protected function setUp(): void
     {
         $this->traitSetUp();

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -11,6 +11,11 @@ class UserManagementTest extends TestCase
         setUp as traitSetUp;
     }
 
+    /**
+     * @var UserManagement
+     */
+    protected $userManagement;
+
     protected function setUp(): void
     {
         $this->traitSetUp();

--- a/tests/WorkOS/WebhookTest.php
+++ b/tests/WorkOS/WebhookTest.php
@@ -10,6 +10,41 @@ class WebhookTest extends TestCase
         setUp as protected traitSetUp;
     }
 
+    /**
+     * @var Webhook
+     */
+    protected $ap;
+
+    /**
+     * @var string
+     */
+    protected $payload;
+
+    /**
+     * @var string
+     */
+    protected $secret;
+
+    /**
+     * @var int
+     */
+    protected $tolerance;
+
+    /**
+     * @var int
+     */
+    protected $time;
+
+    /**
+     * @var string
+     */
+    protected $expectedSignature;
+
+    /**
+     * @var string
+     */
+    protected $sigHeader;
+
     protected function setUp(): void
     {
         $this->traitSetUp();
@@ -21,7 +56,7 @@ class WebhookTest extends TestCase
         $this->secret = 'secret';
         $this->tolerance = 180;
         $this->time = time();
-        $decodedBody = utf8_decode($this->payload);
+        $decodedBody = $this->payload;
         $signedPayload = $this->time . "." . $decodedBody;
         $this->expectedSignature = hash_hmac("sha256", $signedPayload, $this->secret, false);
         $this->sigHeader = 't=' . $this->time . ', v1=' . $this->expectedSignature;

--- a/tests/WorkOS/WidgetsTest.php
+++ b/tests/WorkOS/WidgetsTest.php
@@ -10,6 +10,11 @@ class WidgetsTest extends TestCase
         setUp as protected traitSetUp;
     }
 
+    /**
+     * @var Widgets
+     */
+    protected $ap;
+
     protected function setUp(): void
     {
         $this->traitSetUp();


### PR DESCRIPTION
## Description
The tests were throwing deprecation notices due to dynamic class properties being set. This PR resolves them by explicitly setting the properties.

Example of a notice that was thrown:

`Deprecated: Creation of dynamic property WorkOS\WebhookTest::$payload is deprecated`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
