### PR TITLE
Adds multiple roles support to OrganizationMembership Create and Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ vendor/
 # PHPUnit
 /.phpunit.cache
 .phpunit.result.cache
+
+# IDEs
+.idea/

--- a/lib/Resource/OrganizationMembership.php
+++ b/lib/Resource/OrganizationMembership.php
@@ -10,6 +10,7 @@ namespace WorkOS\Resource;
  * @property string $userId
  * @property string $organizationId
  * @property RoleResponse $role
+ * @property array<RoleResponse> $roles
  * @property 'active'|'inactive'|'pending' $status
  * @property string $createdAt
  * @property string $updatedAt
@@ -24,6 +25,7 @@ class OrganizationMembership extends BaseWorkOSResource
         "userId",
         "organizationId",
         "role",
+        "roles",
         "status",
         "createdAt",
         "updatedAt"
@@ -35,6 +37,7 @@ class OrganizationMembership extends BaseWorkOSResource
         "user_id" => "userId",
         "organization_id" => "organizationId",
         "role" => "role",
+        "roles" => "roles",
         "status" => "status",
         "created_at" => "createdAt",
         "updated_at" => "updatedAt"

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -234,10 +234,16 @@ class UserManagement
 
         $params = [
             "organization_id" => $organizationId,
-            "user_id" => $userId,
-            "role_slug" => $roleSlug,
-            "role_slugs" => $roleSlugs
+            "user_id" => $userId
         ];
+
+        if (!is_null($roleSlug)) {
+            $params["role_slug"] = $roleSlug;
+        }
+
+        if (!is_null($roleSlugs)) {
+            $params["role_slugs"] = $roleSlugs;
+        }
 
         $response = Client::request(
             Client::METHOD_POST,
@@ -313,10 +319,15 @@ class UserManagement
     {
         $path = "user_management/organization_memberships/{$organizationMembershipId}";
 
-        $params = [
-            "role_slug" => $roleSlug,
-            "role_slugs" => $roleSlugs
-        ];
+        $params = [];
+
+        if (!is_null($roleSlug)) {
+            $params["role_slug"] = $roleSlug;
+        }
+
+        if (!is_null($roleSlugs)) {
+            $params["role_slugs"] = $roleSlugs;
+        }
 
         $response = Client::request(
             Client::METHOD_PUT,

--- a/lib/UserManagement.php
+++ b/lib/UserManagement.php
@@ -222,19 +222,21 @@ class UserManagement
      * @param string $userId User ID
      * @param string $organizationId Organization ID
      * @param string|null $roleSlug Role Slug
+     * @param string|null $roleSlugs Role Slugs
      *
      * @throws Exception\WorkOSException
      *
      * @return Resource\OrganizationMembership
      */
-    public function createOrganizationMembership($userId, $organizationId, $roleSlug = null)
+    public function createOrganizationMembership($userId, $organizationId, $roleSlug = null, $roleSlugs = null)
     {
         $path = "user_management/organization_memberships";
 
         $params = [
             "organization_id" => $organizationId,
             "user_id" => $userId,
-            "role_slug" => $roleSlug
+            "role_slug" => $roleSlug,
+            "role_slugs" => $roleSlugs
         ];
 
         $response = Client::request(
@@ -300,18 +302,20 @@ class UserManagement
      * Update a User organization membership.
      *
      * @param string $organizationMembershipId Organization Membership ID
-     * @param string|null $role_slug The unique role identifier.
+     * @param string|null $role_slug The unique slug of the role to grant to this membership.
+     * @param string|null $role_slugs The unique slugs of the roles to grant to this membership.
      *
      * @throws Exception\WorkOSException
      *
      * @return Resource\OrganizationMembership
      */
-    public function updateOrganizationMembership($organizationMembershipId, $roleSlug = null)
+    public function updateOrganizationMembership($organizationMembershipId, $roleSlug = null, $roleSlugs = null)
     {
         $path = "user_management/organization_memberships/{$organizationMembershipId}";
 
         $params = [
-            "role_slug" => $roleSlug
+            "role_slug" => $roleSlug,
+            "role_slugs" => $roleSlugs
         ];
 
         $response = Client::request(

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -894,7 +894,6 @@ class UserManagementTest extends TestCase
             "organization_id" => $orgId,
             "user_id" => $userId,
             "role_slug" => $roleSlug,
-            "role_slugs" => null,
         ];
 
         $this->mockRequest(
@@ -925,7 +924,6 @@ class UserManagementTest extends TestCase
         $params = [
             "organization_id" => $orgId,
             "user_id" => $userId,
-            "role_slug" => null,
             "role_slugs" => $roleSlugs,
         ];
 
@@ -1104,7 +1102,7 @@ class UserManagementTest extends TestCase
             Client::METHOD_PUT,
             $path,
             null,
-            ["role_slug" => $roleSlug, "role_slugs" => null],
+            ["role_slug" => $roleSlug],
             true,
             $result
         );
@@ -1125,7 +1123,7 @@ class UserManagementTest extends TestCase
             Client::METHOD_PUT,
             $path,
             null,
-            ["role_slug" => null, "role_slugs" => $roleSlugs],
+            ["role_slugs" => $roleSlugs],
             true,
             $result
         );

--- a/tests/WorkOS/UserManagementTest.php
+++ b/tests/WorkOS/UserManagementTest.php
@@ -893,7 +893,8 @@ class UserManagementTest extends TestCase
         $params = [
             "organization_id" => $orgId,
             "user_id" => $userId,
-            "role_slug" => $roleSlug
+            "role_slug" => $roleSlug,
+            "role_slugs" => null,
         ];
 
         $this->mockRequest(
@@ -908,6 +909,38 @@ class UserManagementTest extends TestCase
         $organizationMembership = $this->organizationMembershipFixture();
 
         $response = $this->userManagement->createOrganizationMembership($userId, $orgId, $roleSlug);
+
+        $this->assertSame($organizationMembership, $response->toArray());
+    }
+
+    public function testCreateOrganizationMembershipWithRoleSlugs()
+    {
+        $userId = "user_01H7X1M4TZJN5N4HG4XXMA1234";
+        $orgId = "org_01EHQMYV6MBK39QC5PZXHY59C3";
+        $roleSlugs = ["admin"];
+        $path = "user_management/organization_memberships";
+
+        $result = $this->organizationMembershipResponseFixture();
+
+        $params = [
+            "organization_id" => $orgId,
+            "user_id" => $userId,
+            "role_slug" => null,
+            "role_slugs" => $roleSlugs,
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $path,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $organizationMembership = $this->organizationMembershipFixture();
+
+        $response = $this->userManagement->createOrganizationMembership($userId, $orgId, null, $roleSlugs);
 
         $this->assertSame($organizationMembership, $response->toArray());
     }
@@ -1071,7 +1104,7 @@ class UserManagementTest extends TestCase
             Client::METHOD_PUT,
             $path,
             null,
-            ["role_slug" => $roleSlug],
+            ["role_slug" => $roleSlug, "role_slugs" => null],
             true,
             $result
         );
@@ -1079,6 +1112,28 @@ class UserManagementTest extends TestCase
         $response = $this->userManagement->updateOrganizationMembership($organizationMembershipId, $roleSlug);
         $this->assertSame($this->organizationMembershipFixture(), $response->toArray());
     }
+
+    public function testUpdateOrganizationMembershipWithRoleSlugs()
+    {
+        $organizationMembershipId = "om_01E4ZCR3C56J083X43JQXF3JK5";
+        $roleSlugs = ["admin"];
+        $path = "user_management/organization_memberships/{$organizationMembershipId}";
+
+        $result = $this->organizationMembershipResponseFixture();
+
+        $this->mockRequest(
+            Client::METHOD_PUT,
+            $path,
+            null,
+            ["role_slug" => null, "role_slugs" => $roleSlugs],
+            true,
+            $result
+        );
+
+        $response = $this->userManagement->updateOrganizationMembership($organizationMembershipId, null, $roleSlugs);
+        $this->assertSame($this->organizationMembershipFixture(), $response->toArray());
+    }
+
 
     public function testDeactivateOrganizationMembership()
     {
@@ -1396,6 +1451,11 @@ class UserManagementTest extends TestCase
             "role" => [
                 "slug" => "admin",
             ],
+            "roles" => [
+                [
+                    "slug" => "admin",
+                ],
+            ],
             "status" => $status,
             "created_at" => "2021-06-25T19:07:33.155Z",
             "updated_at" => "2021-06-25T19:07:33.155Z",
@@ -1414,6 +1474,11 @@ class UserManagementTest extends TestCase
                         "organization_id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
                         "role" => [
                             "slug" => "admin",
+                        ],
+                        "roles" => [
+                            [
+                                "slug" => "admin",
+                            ]
                         ],
                         "status" => "active",
                         "created_at" => "2021-06-25T19:07:33.155Z",
@@ -1437,6 +1502,11 @@ class UserManagementTest extends TestCase
             "organizationId" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
             "role" => [
                 "slug" => "admin",
+            ],
+            "roles" => [
+                [
+                    "slug" => "admin",
+                ],
             ],
             "status" => "active",
             "createdAt" => "2021-06-25T19:07:33.155Z",


### PR DESCRIPTION
## Description

- Add `roles` to organization membership resource responses (get, list, create, update, deactivate, reactivate)
- Add `roleSlugs` parameter to organization membership create and update options

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

Will update the docs for these changes in **ENT-3687**

## Testing

Tested locally against a team with multiple roles enabled. I tested OM get and update.