### PR TITLE
Version bump to 4.27.0

### DIFF
--- a/lib/Version.php
+++ b/lib/Version.php
@@ -6,5 +6,5 @@ final class Version
 {
     public const SDK_IDENTIFIER = 'WorkOS PHP';
 
-    public const SDK_VERSION = '4.26.0';
+    public const SDK_VERSION = '4.27.0';
 }


### PR DESCRIPTION
## Description
Version bump to 4.2.7.0

Includes:
- https://github.com/workos/workos-php/pull/291
- https://github.com/workos/workos-php/pull/293
- https://github.com/workos/workos-php/pull/302

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
