### PR TITLE
feat!: bump minimum supported PHP version to 8.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Lint
 
 on:
   push:
@@ -11,32 +11,28 @@ defaults:
     shell: bash
 
 jobs:
-  test:
-    name: Test PHP ${{ matrix.php }}
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        php: ["8.1", "8.2", "8.3", "8.4", "8.5"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
         with:
-          php-version: ${{ matrix.php }}
+          php-version: "8.1"
           tools: "composer"
 
       - name: Cache Composer packages
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php-8.1-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php }}-
+            ${{ runner.os }}-php-8.1-
 
       - name: Install dependencies
         run: |
           composer install --prefer-dist --no-progress --no-interaction
 
-      - name: Test
+      - name: Lint and formatting
         run: |
-          composer run-script test
+          composer run-script format-check

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "[github-actions-workflow]": {
+        "editor.defaultFormatter": "redhat.vscode-yaml"
+    },
+    "[json]": {
+        "editor.defaultFormatter": "vscode.json-language-features"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
     }
   ],
   "require": {
-    "php": ">=7.3.0",
+    "php": ">=8.1.0",
     "ext-curl": "*",
-    "paragonie/halite": "^4.0"
+    "paragonie/halite": "^5.1"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2.15|^3.6",
-    "phpunit/phpunit": "^9"
+    "friendsofphp/php-cs-fixer": "^3.0",
+    "phpunit/phpunit": "^10.5"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
## Description

This PR raises our minimum supported PHP version to 8.1, which was [released two years ago](https://endoflife.date/php) and reached end of official support about two months ago.

PHP 8.0 reached end of official support two years ago, and I’d like our SDKs to support only language versions that have been out of support for no more than a year.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
