### PR TITLE
fix: deprecation on PHP 8.5

### DIFF
--- a/lib/RequestClient/CurlRequestClient.php
+++ b/lib/RequestClient/CurlRequestClient.php
@@ -113,14 +113,18 @@ class CurlRequestClient implements RequestClientInterface
         if ($result === false) {
             $errno = \curl_errno($curl);
             $msg = \curl_error($curl);
-            \curl_close($curl);
+            if (PHP_VERSION_ID < 80500) {
+                \curl_close($curl);
+            }
 
             throw new GenericException($msg, ["curlErrno" => $errno]);
         } else {
             // Unsure how versions of cURL and PHP correlate so using the legacy
             // reference for getting the last response code
             $statusCode = \curl_getinfo($curl, \CURLINFO_RESPONSE_CODE);
-            \curl_close($curl);
+            if (PHP_VERSION_ID < 80500) {
+                \curl_close($curl);
+            }
 
             return [$result, $headers, $statusCode];
         }

--- a/lib/RequestClient/CurlRequestClient.php
+++ b/lib/RequestClient/CurlRequestClient.php
@@ -113,7 +113,7 @@ class CurlRequestClient implements RequestClientInterface
         if ($result === false) {
             $errno = \curl_errno($curl);
             $msg = \curl_error($curl);
-            if (PHP_VERSION_ID < 80500) {
+            if (PHP_VERSION_ID < 80000) {
                 \curl_close($curl);
             }
 
@@ -122,7 +122,7 @@ class CurlRequestClient implements RequestClientInterface
             // Unsure how versions of cURL and PHP correlate so using the legacy
             // reference for getting the last response code
             $statusCode = \curl_getinfo($curl, \CURLINFO_RESPONSE_CODE);
-            if (PHP_VERSION_ID < 80500) {
+            if (PHP_VERSION_ID < 80000) {
                 \curl_close($curl);
             }
 


### PR DESCRIPTION
Hi @gjtorikian @sheldonvaughn,

## Description

Since PHP8.5 curl_close is deprecated and the call is only useful for PHP 7.
https://www.php.net/manual/en/function.curl-close.php

This prevent the deprecation
```
Deprecated: Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0
```

It would be great having a patch release with this.

## Documentation

Does not require change to the doc
