### PR TITLE
fix: add default User-Agent header and optional override

### DIFF
--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -37,6 +37,7 @@ class HttpClient
         private readonly int $timeout,
         private readonly int $maxRetries,
         ?\GuzzleHttp\HandlerStack $handler = null,
+        private readonly ?string $userAgent = null,
     ) {
         $this->client = new Client([
             'handler' => $handler,
@@ -176,6 +177,7 @@ class HttpClient
     ): array {
         $headers = [
             'Content-Type' => 'application/json',
+            'User-Agent' => $this->userAgent ?? sprintf('%s/%s', Version::SDK_IDENTIFIER, Version::SDK_VERSION),
         ];
 
         if ($this->getApiKey() !== null) {

--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -177,7 +177,6 @@ class HttpClient
     ): array {
         $headers = [
             'Content-Type' => 'application/json',
-            'User-Agent' => $this->userAgent ?? sprintf('%s/%s', Version::SDK_IDENTIFIER, Version::SDK_VERSION),
         ];
 
         if ($this->getApiKey() !== null) {
@@ -191,6 +190,9 @@ class HttpClient
         if ($options?->idempotencyKey !== null) {
             $headers['Idempotency-Key'] = $options->idempotencyKey;
         }
+
+        // Always set User-Agent last so callers cannot override it via extraHeaders.
+        $headers['User-Agent'] = $this->userAgent ?? sprintf('%s/%s', Version::SDK_IDENTIFIER, Version::SDK_VERSION);
 
         $requestOptions = [
             'headers' => $headers,

--- a/lib/WorkOS.php
+++ b/lib/WorkOS.php
@@ -80,10 +80,11 @@ class WorkOS
         int $timeout = 60,
         int $maxRetries = 3,
         ?\GuzzleHttp\HandlerStack $handler = null,
+        ?string $userAgent = null,
     ) {
         $apiKey ??= getenv('WORKOS_API_KEY') ?: self::$apiKey ?? '';
         $clientId ??= getenv('WORKOS_CLIENT_ID') ?: self::$clientId;
-        $this->httpClient = new HttpClient($apiKey, $clientId, $baseUrl, $timeout, $maxRetries, $handler);
+        $this->httpClient = new HttpClient($apiKey, $clientId, $baseUrl, $timeout, $maxRetries, $handler, $userAgent);
     }
 
     public function apiKeys(): ApiKeys

--- a/tests/Service/RuntimeBehaviorTest.php
+++ b/tests/Service/RuntimeBehaviorTest.php
@@ -155,7 +155,7 @@ class RuntimeBehaviorTest extends TestCase
         );
     }
 
-    public function testPerRequestUserAgentBeatsConstructorUserAgent(): void
+    public function testPerRequestExtraHeadersCannotOverrideUserAgent(): void
     {
         $client = $this->createMockClient(
             [['status' => 200, 'body' => $this->loadFixture('organization')]],
@@ -168,7 +168,7 @@ class RuntimeBehaviorTest extends TestCase
         );
 
         $this->assertSame(
-            'Custom/9.9.9',
+            'WorkOS PHP Laravel/5.1.0',
             $this->getLastRequest()->getHeaderLine('User-Agent'),
         );
     }

--- a/tests/Service/RuntimeBehaviorTest.php
+++ b/tests/Service/RuntimeBehaviorTest.php
@@ -9,6 +9,7 @@ use WorkOS\Exception\AuthenticationException;
 use WorkOS\Exception\RateLimitExceededException;
 use WorkOS\RequestOptions;
 use WorkOS\TestHelper;
+use WorkOS\Version;
 
 class RuntimeBehaviorTest extends TestCase
 {
@@ -123,6 +124,53 @@ class RuntimeBehaviorTest extends TestCase
             $this->assertSame('req_auth', $exception->requestId);
             $this->assertSame('Nope', $exception->getMessage());
         }
+    }
+
+    public function testDefaultUserAgentIdentifiesTheSdk(): void
+    {
+        $client = $this->createMockClient([
+            ['status' => 200, 'body' => $this->loadFixture('organization')],
+        ]);
+
+        $client->organizations()->getOrganization('org_123');
+
+        $this->assertSame(
+            sprintf('%s/%s', Version::SDK_IDENTIFIER, Version::SDK_VERSION),
+            $this->getLastRequest()->getHeaderLine('User-Agent'),
+        );
+    }
+
+    public function testConstructorUserAgentOverridesDefault(): void
+    {
+        $client = $this->createMockClient(
+            [['status' => 200, 'body' => $this->loadFixture('organization')]],
+            userAgent: 'WorkOS PHP Laravel/5.1.0',
+        );
+
+        $client->organizations()->getOrganization('org_123');
+
+        $this->assertSame(
+            'WorkOS PHP Laravel/5.1.0',
+            $this->getLastRequest()->getHeaderLine('User-Agent'),
+        );
+    }
+
+    public function testPerRequestUserAgentBeatsConstructorUserAgent(): void
+    {
+        $client = $this->createMockClient(
+            [['status' => 200, 'body' => $this->loadFixture('organization')]],
+            userAgent: 'WorkOS PHP Laravel/5.1.0',
+        );
+
+        $client->organizations()->getOrganization(
+            'org_123',
+            new RequestOptions(extraHeaders: ['User-Agent' => 'Custom/9.9.9']),
+        );
+
+        $this->assertSame(
+            'Custom/9.9.9',
+            $this->getLastRequest()->getHeaderLine('User-Agent'),
+        );
     }
 
     public function testRateLimitErrorsExposeRetryAfter(): void

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -30,6 +30,7 @@ trait TestHelper
         ?string $clientId = 'test_client_id',
         string $baseUrl = 'https://api.workos.com',
         int $maxRetries = 3,
+        ?string $userAgent = null,
     ): WorkOS {
         $mockResponses = array_map(
             fn (array $response) => new Response(
@@ -51,6 +52,7 @@ trait TestHelper
             baseUrl: $baseUrl,
             maxRetries: $maxRetries,
             handler: $handler,
+            userAgent: $userAgent,
         );
     }
 


### PR DESCRIPTION
## Summary

v5 accidentally dropped the outbound `User-Agent` header identifying the SDK. 

This is now restored, resulting in `"WorkOS PHP/<Version::SDK_VERSION>"` sourced from `lib/Version.php`. Previously no `User-Agent` was sent at all, so server-side telemetry couldn't distinguish SDK traffic from other PHP clients.
