### PR TITLE
chore: mark non-spec service accessors with `@oagen-ignore-start/end`

### DIFF
--- a/.oagen-manifest.json
+++ b/.oagen-manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "language": "php",
-  "generatedAt": "2026-04-13T18:28:08.422Z",
+  "generatedAt": "2026-04-14T16:30:42.080Z",
   "files": [
     "lib/Resource/ActionAuthenticationDenied.php",
     "lib/Resource/ActionAuthenticationDeniedData.php",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "format": "php vendor/bin/php-cs-fixer fix -v --using-cache=no --config=.php-cs-fixer.dist.php",
     "format-check": "php vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no --config=.php-cs-fixer.dist.php",
     "test": "php vendor/bin/phpunit tests",
-    "typecheck": "php vendor/bin/phpstan analyse --no-progress",
+    "typecheck": "php vendor/bin/phpstan analyse --no-progress --memory-limit=512M",
     "ci": "./script/ci"
   },
   "config": {

--- a/lib/WorkOS.php
+++ b/lib/WorkOS.php
@@ -66,12 +66,14 @@ class WorkOS
     private ?Service\Webhooks $webhooks = null;
     private ?Service\Widgets $widgets = null;
     private ?Service\AuditLogs $auditLogs = null;
+    // @oagen-ignore-start — non-spec service properties (hand-maintained)
     private ?Passwordless $passwordless = null;
     private ?Vault $vault = null;
     private ?WebhookVerification $webhookVerification = null;
     private ?Actions $actions = null;
     private ?SessionManager $sessionManager = null;
     private ?PKCEHelper $pkce = null;
+    // @oagen-ignore-end
 
     public function __construct(
         ?string $apiKey = null,
@@ -172,6 +174,8 @@ class WorkOS
         return $this->auditLogs ??= new Service\AuditLogs($this->httpClient);
     }
 
+    // @oagen-ignore-start — non-spec service accessors (hand-maintained)
+
     public function passwordless(): Passwordless
     {
         return $this->passwordless ??= new Passwordless($this->httpClient);
@@ -201,4 +205,5 @@ class WorkOS
     {
         return $this->pkce ??= new PKCEHelper($this->httpClient);
     }
+    // @oagen-ignore-end
 }

--- a/script/ci
+++ b/script/ci
@@ -16,7 +16,7 @@ php vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no --config=.php-cs-f
 
 echo ""
 echo "==> Running typecheck (PHPStan)..."
-php vendor/bin/phpstan analyse --no-progress
+php vendor/bin/phpstan analyse --no-progress --memory-limit=512M
 
 echo ""
 echo "==> Running tests (PHPUnit)..."


### PR DESCRIPTION
Previously, oagen-emitters generated methods for APIs not in the OpenAPI spec—stuff like Vault, PKCE, etc. This was kind of gross and unnecessary, so I removed the functionality in https://github.com/workos/oagen-emitters/commit/7b0bab4a622edd99aee7fcc37dd67b695384ef67 and am just tagging the relevant code sections with `oagen-ignore`, so that they do not get removed upon regeneration.