### PR TITLE
feat: surface error metadata from API responses

### DIFF
--- a/lib/Exception/ApiException.php
+++ b/lib/Exception/ApiException.php
@@ -14,6 +14,8 @@ class ApiException extends \Exception implements WorkOSException
         public readonly ?int $statusCode = null,
         public readonly ?string $requestId = null,
         ?\Throwable $previous = null,
+        public readonly ?string $errorCode = null,
+        public readonly ?string $error = null,
     ) {
         parent::__construct($message, $statusCode ?? 0, $previous);
     }
@@ -21,6 +23,8 @@ class ApiException extends \Exception implements WorkOSException
     public static function fromResponse(int $statusCode, array $body, ?string $requestId = null): static
     {
         $message = $body['message'] ?? 'Unknown error';
-        return new static($message, $statusCode, $requestId);
+        $errorCode = $body['code'] ?? null;
+        $error = $body['error'] ?? null;
+        return new static($message, $statusCode, $requestId, null, $errorCode, $error);
     }
 }

--- a/lib/Exception/ApiException.php
+++ b/lib/Exception/ApiException.php
@@ -23,8 +23,8 @@ class ApiException extends \Exception implements WorkOSException
     public static function fromResponse(int $statusCode, array $body, ?string $requestId = null): static
     {
         $message = $body['message'] ?? 'Unknown error';
-        $errorCode = $body['code'] ?? null;
-        $error = $body['error'] ?? null;
+        $errorCode = isset($body['code']) && is_string($body['code']) ? $body['code'] : null;
+        $error = isset($body['error']) && is_string($body['error']) ? $body['error'] : null;
         return new static($message, $statusCode, $requestId, null, $errorCode, $error);
     }
 }

--- a/lib/Exception/RateLimitExceededException.php
+++ b/lib/Exception/RateLimitExceededException.php
@@ -15,9 +15,11 @@ class RateLimitExceededException extends BaseRequestException
         ?int $statusCode = 429,
         ?string $requestId = null,
         ?\Throwable $previous = null,
+        ?string $errorCode = null,
+        ?string $error = null,
         ?int $retryAfter = null,
     ) {
-        parent::__construct($message, $statusCode, $requestId, $previous);
+        parent::__construct($message, $statusCode, $requestId, $previous, $errorCode, $error);
         $this->retryAfter = $retryAfter;
     }
 }

--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -285,43 +285,47 @@ class HttpClient
         $body = $this->decodeErrorBody($response);
 
         return match ($statusCode) {
-            400 => new BadRequestException($body['message'], $statusCode, $requestId, $previous),
-            401 => new AuthenticationException($body['message'], $statusCode, $requestId, $previous),
-            403 => new AuthorizationException($body['message'], $statusCode, $requestId, $previous),
-            404 => new NotFoundException($body['message'], $statusCode, $requestId, $previous),
-            409 => new ConflictException($body['message'], $statusCode, $requestId, $previous),
-            422 => new UnprocessableEntityException($body['message'], $statusCode, $requestId, $previous),
+            400 => new BadRequestException($body['message'], $statusCode, $requestId, $previous, $body['code'], $body['error']),
+            401 => new AuthenticationException($body['message'], $statusCode, $requestId, $previous, $body['code'], $body['error']),
+            403 => new AuthorizationException($body['message'], $statusCode, $requestId, $previous, $body['code'], $body['error']),
+            404 => new NotFoundException($body['message'], $statusCode, $requestId, $previous, $body['code'], $body['error']),
+            409 => new ConflictException($body['message'], $statusCode, $requestId, $previous, $body['code'], $body['error']),
+            422 => new UnprocessableEntityException($body['message'], $statusCode, $requestId, $previous, $body['code'], $body['error']),
             429 => new RateLimitExceededException(
                 $body['message'],
                 $statusCode,
                 $requestId,
                 $previous,
+                $body['code'],
+                $body['error'],
                 $this->parseRetryAfter($response->getHeaderLine('Retry-After')),
             ),
-            500, 502, 503, 504 => new ServerException($body['message'], $statusCode, $requestId, $previous),
-            default => new BaseRequestException($body['message'], $statusCode, $requestId, $previous),
+            500, 502, 503, 504 => new ServerException($body['message'], $statusCode, $requestId, $previous, $body['code'], $body['error']),
+            default => new BaseRequestException($body['message'], $statusCode, $requestId, $previous, $body['code'], $body['error']),
         };
     }
 
     /**
-     * @return array{message: string}
+     * @return array{message: string, code: ?string, error: ?string}
      */
     private function decodeErrorBody(ResponseInterface $response): array
     {
         $contents = (string) $response->getBody();
         if ($contents === '') {
-            return ['message' => sprintf('WorkOS request failed with status %d.', $response->getStatusCode())];
+            return ['message' => sprintf('WorkOS request failed with status %d.', $response->getStatusCode()), 'code' => null, 'error' => null];
         }
 
         $decoded = json_decode($contents, true);
         if (is_array($decoded)) {
             $message = $decoded['message'] ?? $decoded['error_description'] ?? $decoded['error'] ?? null;
             if (is_string($message) && $message !== '') {
-                return ['message' => $message];
+                $code = isset($decoded['code']) && is_string($decoded['code']) ? $decoded['code'] : null;
+                $error = isset($decoded['error']) && is_string($decoded['error']) ? $decoded['error'] : null;
+                return ['message' => $message, 'code' => $code, 'error' => $error];
             }
         }
 
-        return ['message' => $contents];
+        return ['message' => $contents, 'code' => null, 'error' => null];
     }
 
     private function mapTransportException(\Throwable $exception): \Exception

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -10,6 +10,8 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use WorkOS\Exception\ApiException;
+use WorkOS\Exception\BadRequestException;
+use WorkOS\Exception\RateLimitExceededException;
 use WorkOS\HttpClient;
 
 class HttpClientTest extends TestCase
@@ -81,5 +83,156 @@ class HttpClientTest extends TestCase
         parse_str(parse_url($url, PHP_URL_QUERY) ?? '', $query);
         $this->assertSame('abc', $query['client_id']);
         $this->assertSame('code', $query['response_type']);
+    }
+
+    public function testErrorResponseIncludesCodeAndError(): void
+    {
+        $body = json_encode([
+            'message' => 'Organization not found',
+            'code' => 'entity_not_found',
+            'error' => 'not_found',
+        ]);
+
+        $mock = new MockHandler([
+            new Response(400, ['Content-Type' => 'application/json'], $body),
+        ]);
+
+        $client = new HttpClient(
+            apiKey: 'test_key',
+            clientId: null,
+            baseUrl: 'https://api.workos.com',
+            timeout: 10,
+            maxRetries: 0,
+            handler: HandlerStack::create($mock),
+        );
+
+        try {
+            $client->request('GET', '/test');
+            $this->fail('Expected BadRequestException');
+        } catch (BadRequestException $e) {
+            $this->assertSame('Organization not found', $e->getMessage());
+            $this->assertSame(400, $e->statusCode);
+            $this->assertSame('entity_not_found', $e->errorCode);
+            $this->assertSame('not_found', $e->error);
+        }
+    }
+
+    public function testErrorResponseOmittingCodeAndErrorSetsNull(): void
+    {
+        $body = json_encode(['message' => 'Something went wrong']);
+
+        $mock = new MockHandler([
+            new Response(422, ['Content-Type' => 'application/json'], $body),
+        ]);
+
+        $client = new HttpClient(
+            apiKey: 'test_key',
+            clientId: null,
+            baseUrl: 'https://api.workos.com',
+            timeout: 10,
+            maxRetries: 0,
+            handler: HandlerStack::create($mock),
+        );
+
+        try {
+            $client->request('GET', '/test');
+            $this->fail('Expected ApiException');
+        } catch (ApiException $e) {
+            $this->assertSame('Something went wrong', $e->getMessage());
+            $this->assertNull($e->errorCode);
+            $this->assertNull($e->error);
+        }
+    }
+
+    public function testRateLimitExceptionIncludesRetryAfterAndErrorFields(): void
+    {
+        $body = json_encode([
+            'message' => 'Rate limit exceeded',
+            'code' => 'rate_limit',
+            'error' => 'too_many_requests',
+        ]);
+
+        $mock = new MockHandler([
+            new Response(429, [
+                'Content-Type' => 'application/json',
+                'Retry-After' => '30',
+            ], $body),
+        ]);
+
+        $client = new HttpClient(
+            apiKey: 'test_key',
+            clientId: null,
+            baseUrl: 'https://api.workos.com',
+            timeout: 10,
+            maxRetries: 0,
+            handler: HandlerStack::create($mock),
+        );
+
+        try {
+            $client->request('GET', '/test');
+            $this->fail('Expected RateLimitExceededException');
+        } catch (RateLimitExceededException $e) {
+            $this->assertSame('Rate limit exceeded', $e->getMessage());
+            $this->assertSame(429, $e->statusCode);
+            $this->assertSame('rate_limit', $e->errorCode);
+            $this->assertSame('too_many_requests', $e->error);
+            $this->assertSame(30, $e->retryAfter);
+        }
+    }
+
+    public function testEmptyErrorBodySetsNullCodeAndError(): void
+    {
+        $mock = new MockHandler([
+            new Response(500, ['Content-Type' => 'application/json'], ''),
+        ]);
+
+        $client = new HttpClient(
+            apiKey: 'test_key',
+            clientId: null,
+            baseUrl: 'https://api.workos.com',
+            timeout: 10,
+            maxRetries: 0,
+            handler: HandlerStack::create($mock),
+        );
+
+        try {
+            $client->request('GET', '/test');
+            $this->fail('Expected ApiException');
+        } catch (ApiException $e) {
+            $this->assertStringContainsString('WorkOS request failed with status 500', $e->getMessage());
+            $this->assertNull($e->errorCode);
+            $this->assertNull($e->error);
+        }
+    }
+
+    public function testNonStringCodeFieldIsIgnored(): void
+    {
+        $body = json_encode([
+            'message' => 'Validation failed',
+            'code' => 42,
+            'error' => ['nested' => 'object'],
+        ]);
+
+        $mock = new MockHandler([
+            new Response(400, ['Content-Type' => 'application/json'], $body),
+        ]);
+
+        $client = new HttpClient(
+            apiKey: 'test_key',
+            clientId: null,
+            baseUrl: 'https://api.workos.com',
+            timeout: 10,
+            maxRetries: 0,
+            handler: HandlerStack::create($mock),
+        );
+
+        try {
+            $client->request('GET', '/test');
+            $this->fail('Expected BadRequestException');
+        } catch (BadRequestException $e) {
+            $this->assertSame('Validation failed', $e->getMessage());
+            $this->assertNull($e->errorCode);
+            $this->assertNull($e->error);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `errorCode` and `error` readonly properties to `ApiException`
  and propagate them through `RateLimitExceededException`
- Update `HttpClient::decodeErrorBody()` to extract `code` and
  `error` from JSON error responses alongside the existing `message`
- Pass these fields through to all exception constructors in the
  HTTP status code match expression

This lets SDK consumers distinguish error types programmatically
(e.g. validation codes, rate-limit reasons) without parsing the
human-readable message string.

## Test plan
- [ ] Verify exceptions include `errorCode` and `error` when API
      returns them in the response body
- [ ] Verify `errorCode` and `error` are `null` when the API
      response omits those fields
- [ ] Verify `RateLimitExceededException` still correctly captures
      the `Retry-After` header alongside the new fields