### PR TITLE
fix: reject path-traversal sequences in HttpClient::resolveUrl

### DIFF
--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -251,12 +251,13 @@ class HttpClient
      * in a single ID would silently re-target the request at a different
      * WorkOS resource under the application's authenticated API key.
      *
-     * The check runs against the percent-decoded path so that encoded
-     * variants (`%2e%2e`, `%2f`, `%3f`, `%0d%0a`, ...) cannot bypass it.
+     * The check runs against the fully percent-decoded path so that encoded
+     * variants (`%2e%2e`, `%2f`, `%3f`, `%0d%0a`, ...) and double-encoded
+     * variants (`%252e%252e`, `%252f`, ...) cannot bypass it.
      */
     private function assertSafePath(string $path): void
     {
-        $decoded = rawurldecode($path);
+        $decoded = self::decodeUntilStable($path);
 
         if (preg_match('/[\x00-\x1f?#]/', $decoded) === 1) {
             throw new \InvalidArgumentException(
@@ -271,6 +272,20 @@ class HttpClient
                 );
             }
         }
+    }
+
+    /**
+     * Decode percent-encoded characters in a loop until the value stabilizes,
+     * closing double-encoding bypass vectors like `%252e%252e`.
+     */
+    private static function decodeUntilStable(string $value): string
+    {
+        do {
+            $prev = $value;
+            $value = rawurldecode($value);
+        } while ($value !== $prev);
+
+        return $value;
     }
 
     private function resolveTimeout(?RequestOptions $options): int

--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -236,9 +236,36 @@ class HttpClient
             return $path;
         }
 
+        $this->assertSafePath($path);
+
         $baseUrl = $options !== null && $options->baseUrl !== null ? $options->baseUrl : $this->baseUrl;
         $baseUrl = rtrim($baseUrl, '/');
         return $baseUrl . '/' . ltrim($path, '/');
+    }
+
+    /**
+     * Reject paths whose segments could escape the intended endpoint once
+     * normalized by the HTTP transport. Service methods interpolate caller-
+     * supplied IDs into path templates without per-segment URL-encoding, so
+     * an unencoded "../" or embedded "?"/"#"/CRLF in a single ID would
+     * silently re-target the request at a different WorkOS resource under
+     * the application's authenticated API key.
+     */
+    private function assertSafePath(string $path): void
+    {
+        if (preg_match('/[\x00-\x1f?#]/', $path) === 1) {
+            throw new \InvalidArgumentException(
+                'WorkOS request path contains a forbidden character (control character, "?", or "#"). Pass query parameters via the $query argument rather than embedding them in the path.',
+            );
+        }
+
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '.' || $segment === '..') {
+                throw new \InvalidArgumentException(
+                    'WorkOS request path contains a relative segment ("." or ".."). Refusing to send the request to avoid cross-resource redirection.',
+                );
+            }
+        }
     }
 
     private function resolveTimeout(?RequestOptions $options): int

--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -245,21 +245,26 @@ class HttpClient
 
     /**
      * Reject paths whose segments could escape the intended endpoint once
-     * normalized by the HTTP transport. Service methods interpolate caller-
-     * supplied IDs into path templates without per-segment URL-encoding, so
-     * an unencoded "../" or embedded "?"/"#"/CRLF in a single ID would
-     * silently re-target the request at a different WorkOS resource under
-     * the application's authenticated API key.
+     * normalized by the HTTP transport or the receiving server. Service
+     * methods interpolate caller-supplied IDs into path templates without
+     * per-segment URL-encoding, so an unencoded "../" or embedded "?"/"#"/CRLF
+     * in a single ID would silently re-target the request at a different
+     * WorkOS resource under the application's authenticated API key.
+     *
+     * The check runs against the percent-decoded path so that encoded
+     * variants (`%2e%2e`, `%2f`, `%3f`, `%0d%0a`, ...) cannot bypass it.
      */
     private function assertSafePath(string $path): void
     {
-        if (preg_match('/[\x00-\x1f?#]/', $path) === 1) {
+        $decoded = rawurldecode($path);
+
+        if (preg_match('/[\x00-\x1f?#]/', $decoded) === 1) {
             throw new \InvalidArgumentException(
                 'WorkOS request path contains a forbidden character (control character, "?", or "#"). Pass query parameters via the $query argument rather than embedding them in the path.',
             );
         }
 
-        foreach (explode('/', $path) as $segment) {
+        foreach (explode('/', $decoded) as $segment) {
             if ($segment === '.' || $segment === '..') {
                 throw new \InvalidArgumentException(
                     'WorkOS request path contains a relative segment ("." or ".."). Refusing to send the request to avoid cross-resource redirection.',

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -99,6 +99,15 @@ class HttpClientTest extends TestCase
             'embedded carriage return' => ["connections/conn_123\r\nHost: evil"],
             'embedded newline' => ["connections/conn_123\nfoo"],
             'embedded null byte' => ["connections/conn_123\x00"],
+            'percent-encoded parent traversal lowercase' => ['connections/%2e%2e/webhook_endpoints/wh_target'],
+            'percent-encoded parent traversal uppercase' => ['connections/%2E%2E/webhook_endpoints/wh_target'],
+            'percent-encoded current directory segment' => ['connections/%2e/id'],
+            'percent-encoded slash hides traversal' => ['connections%2F..%2Fwebhook_endpoints'],
+            'percent-encoded slash hides encoded traversal' => ['connections%2F%2e%2e%2Fwebhook_endpoints'],
+            'percent-encoded query character' => ['connections/conn_123%3Foverride=1'],
+            'percent-encoded fragment character' => ['connections/conn_123%23frag'],
+            'percent-encoded CRLF injection' => ['connections/conn_123%0D%0AHost:%20evil'],
+            'percent-encoded null byte' => ['connections/conn_123%00'],
         ];
     }
 

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -85,6 +85,75 @@ class HttpClientTest extends TestCase
         $this->assertSame('code', $query['response_type']);
     }
 
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function unsafePathProvider(): array
+    {
+        return [
+            'parent traversal segment' => ['connections/../webhook_endpoints/wh_target'],
+            'leading parent traversal' => ['../webhook_endpoints/wh_target'],
+            'current directory segment' => ['connections/./id'],
+            'embedded query character' => ['connections/conn_123?override=1'],
+            'embedded fragment character' => ['connections/conn_123#frag'],
+            'embedded carriage return' => ["connections/conn_123\r\nHost: evil"],
+            'embedded newline' => ["connections/conn_123\nfoo"],
+            'embedded null byte' => ["connections/conn_123\x00"],
+        ];
+    }
+
+    /**
+     * @dataProvider unsafePathProvider
+     */
+    public function testRequestRejectsUnsafePaths(string $path): void
+    {
+        $client = new HttpClient(
+            apiKey: 'test_key',
+            clientId: null,
+            baseUrl: 'https://api.workos.com',
+            timeout: 10,
+            maxRetries: 0,
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $client->request('DELETE', $path);
+    }
+
+    /**
+     * @dataProvider unsafePathProvider
+     */
+    public function testBuildUrlRejectsUnsafePaths(string $path): void
+    {
+        $client = new HttpClient(
+            apiKey: 'test_key',
+            clientId: null,
+            baseUrl: 'https://api.workos.com',
+            timeout: 10,
+            maxRetries: 0,
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $client->buildUrl($path);
+    }
+
+    public function testRequestAllowsSafePathsWithDotsInsideSegments(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], '{}'),
+        ]);
+
+        $client = new HttpClient(
+            apiKey: 'test_key',
+            clientId: null,
+            baseUrl: 'https://api.workos.com',
+            timeout: 10,
+            maxRetries: 0,
+            handler: HandlerStack::create($mock),
+        );
+
+        $this->assertSame([], $client->request('GET', 'users/user.with.dots'));
+    }
+
     public function testErrorResponseIncludesCodeAndError(): void
     {
         $body = json_encode([

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -108,6 +108,10 @@ class HttpClientTest extends TestCase
             'percent-encoded fragment character' => ['connections/conn_123%23frag'],
             'percent-encoded CRLF injection' => ['connections/conn_123%0D%0AHost:%20evil'],
             'percent-encoded null byte' => ['connections/conn_123%00'],
+            'double-encoded parent traversal' => ['connections/%252e%252e/webhook_endpoints'],
+            'double-encoded slash hides traversal' => ['connections%252F..%252Fwebhook_endpoints'],
+            'double-encoded query character' => ['connections/conn_123%253Foverride=1'],
+            'double-encoded null byte' => ['connections/conn_123%2500'],
         ];
     }
 


### PR DESCRIPTION
## Summary

Defense-in-depth runtime guard against a path-traversal / cross-resource-API-call vulnerability.

WorkOS service methods interpolate caller-supplied ids directly into request paths with PHP string interpolation (e.g. `"connections/{$id}"`) without `rawurlencode`-ing them. libcurl normalizes `../` segments before transmission, so a value like `../webhook_endpoints/wh_target` causes the SDK to issue a request against a different WorkOS endpoint while still authenticated with the application's API key — i.e. forged cross-resource API requests under the application's bearer token.

This PR hardens `HttpClient::resolveUrl()` to reject paths containing:

- `.` or `..` segments (between `/` boundaries) — blocks `connections/../webhook_endpoints/...`-style cross-resource redirection
- `?` or `#` — blocks query/fragment injection (queries go through the `$query` argument)
- `\x00`–`\x1f` control characters — blocks CRLF / null-byte injection

Throws `\InvalidArgumentException` without echoing the offending path back, to avoid log injection from CRLF-laden inputs.

## Why this lands separately from the structural fix

The structural fix (per-segment `rawurlencode` at code-generation time) lands in `workos/oagen-emitters` and will require a regen of this SDK. This runtime guard is valuable independently:

- Protects existing PHP SDK users immediately, before the regen ships.
- Stays valuable as defense-in-depth even after the generator fix lands — the guard applies to any future hand-written path code paths or `RequestOptions::baseUrl` overrides as well.
- Both files modified (`lib/HttpClient.php`, `tests/HttpClientTest.php`) carry `@oagen-ignore-file`, so the upcoming regen won't clobber the guard.

## Versioning

Patch release. Public API surface (method signatures, return types, exception types) is unchanged. The new exception path only fires on inputs that were either being exploited or already producing wrong/404 behavior — no legitimate caller passes `..` or control characters as a WorkOS id.

## Test plan
- [x] `vendor/bin/phpunit` — 272 passed, including 17 new tests for the guard (8 unsafe-input cases × 2 entrypoints + 1 positive test that legitimate ids with dots inside a segment still work)
- [x] `vendor/bin/phpstan analyse` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/workos-php/pull/379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
