### PR TITLE
feat: Add API docs generation and llms.txt index

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Publish API Docs
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: pages
+  cancel-in-progress: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+        with:
+          php-version: '8.2'
+          tools: composer
+      - run: ./script/docs
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - name: Archive site
+        run: |
+          tar \
+            --dereference --hard-dereference \
+            --directory docs/_site \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            .
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ vendor/
 
 # IDEs
 .idea/
+
+# API docs
+docs/_site/
+bin/phpDocumentor.phar
+.phpdoc/

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.0",
     "phpstan/phpstan": "^2.1",
-    "phpunit/phpunit": "^11.5"
+    "phpunit/phpunit": "^11.5",
+    "saggre/phpdocumentor-markdown": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpdocumentor
+    configVersion="3"
+    xmlns="https://www.phpdoc.org"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://www.phpdoc.org phpdoc.xsd">
+    <title>WorkOS PHP SDK</title>
+    <paths>
+        <output>docs/_site</output>
+        <cache>.phpdoc/cache</cache>
+    </paths>
+    <version number="latest">
+        <api format="php">
+            <source dsn=".">
+                <path>lib</path>
+            </source>
+            <ignore>
+                <path>tests/**/*</path>
+                <path>vendor/**/*</path>
+            </ignore>
+            <extensions>
+                <extension>php</extension>
+            </extensions>
+        </api>
+    </version>
+    <setting name="graphs.enabled" value="false"/>
+</phpdocumentor>

--- a/script/docs
+++ b/script/docs
@@ -23,3 +23,40 @@ if [ ! -d "$MD_TEMPLATE" ]; then
   exit 1
 fi
 php "$PHPDOC_PHAR" --config phpdoc.dist.xml --template="$MD_TEMPLATE"
+
+# Pass 3: llms.txt — curated index for AI agents, per llmstxt.org.
+# Lists the top-level entry points (Core, Services, Exceptions); the 600+
+# generated Resource DTOs are reachable by walking classes/WorkOS/Resource/.
+SITE="docs/_site"
+{
+  echo "# WorkOS PHP SDK"
+  echo
+  echo "> Official PHP SDK for the WorkOS API: authentication, SSO, Directory Sync, audit logs, and more."
+  echo
+  echo "API reference auto-generated from source. Each class has a parallel \`.md\` file alongside its HTML page."
+  echo
+  echo "## Core"
+  echo
+  find "$SITE/classes/WorkOS" -maxdepth 1 -name "*.md" | sort | while read -r f; do
+    name=$(basename "$f" .md)
+    echo "- [$name](${f#$SITE/})"
+  done
+  echo
+  echo "## Services"
+  echo
+  find "$SITE/classes/WorkOS/Service" -maxdepth 1 -name "*.md" | sort | while read -r f; do
+    name=$(basename "$f" .md)
+    echo "- [$name](${f#$SITE/})"
+  done
+  echo
+  echo "## Exceptions"
+  echo
+  find "$SITE/classes/WorkOS/Exception" -maxdepth 1 -name "*.md" | sort | while read -r f; do
+    name=$(basename "$f" .md)
+    echo "- [$name](${f#$SITE/})"
+  done
+  echo
+  echo "## Optional"
+  echo
+  echo "- [Resource DTOs](classes/WorkOS/Resource/): generated request/response types, one \`.md\` file per class."
+} > "$SITE/llms.txt"

--- a/script/docs
+++ b/script/docs
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+cd "$(dirname "$0")/.."
+PHPDOC_PHAR="bin/phpDocumentor.phar"
+if [ ! -f "$PHPDOC_PHAR" ]; then
+  mkdir -p bin
+  # Pin a recent stable version; check https://github.com/phpDocumentor/phpDocumentor/releases for latest
+  curl -fsSL -o "$PHPDOC_PHAR" "https://phpdoc.org/phpDocumentor.phar"
+  chmod +x "$PHPDOC_PHAR"
+fi
+rm -rf docs/_site
+
+# Pass 1: HTML output via the default template.
+php "$PHPDOC_PHAR" --config phpdoc.dist.xml
+
+# Pass 2: Markdown output alongside HTML for AI agents that want
+# parallel `.md` files. Uses the saggre/phpdocumentor-markdown
+# community template (require-dev). The markdown files are written
+# alongside the HTML in docs/_site/ — same paths, different extensions.
+MD_TEMPLATE="vendor/saggre/phpdocumentor-markdown/themes/markdown"
+if [ ! -d "$MD_TEMPLATE" ]; then
+  echo "Markdown template missing. Run 'composer install' first." >&2
+  exit 1
+fi
+php "$PHPDOC_PHAR" --config phpdoc.dist.xml --template="$MD_TEMPLATE"

--- a/script/docs-serve
+++ b/script/docs-serve
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+cd "$(dirname "$0")/.."
+if [ ! -d docs/_site ]; then
+  ./script/docs
+fi
+exec php -S 127.0.0.1:4000 -t docs/_site


### PR DESCRIPTION
## Summary
- Wire up phpDocumentor to emit HTML and parallel Markdown into `docs/_site`, so humans and AI agents share the same source paths.
- Add a `Publish API Docs` GitHub Pages workflow that builds and deploys on `v*` tags (and on manual dispatch).
- Generate an `llms.txt` index at the site root (per llmstxt.org) listing Core, Service, and Exception classes, with the 600+ generated Resource DTOs called out separately so they don't drown the list.
- Motivation: the PHP SDK had no published reference unlike its sibling SDKs, and the new docs site needed a curated entry point that LLMs could land on without crawling 700+ files.

## Test plan
- [ ] `./script/docs` runs cleanly locally and produces `docs/_site/index.html`, parallel `.md` files, and `docs/_site/llms.txt`.
- [ ] `llms.txt` lists every class under `lib/WorkOS`, `lib/WorkOS/Service`, and `lib/WorkOS/Exception` with working relative links.
- [ ] `./script/docs-serve` serves the site for spot-checking.
- [ ] Trigger the `Publish API Docs` workflow via `workflow_dispatch` and confirm the Pages deploy succeeds.