### PR TITLE
fix(session): require valid JWT expiration

### DIFF
--- a/lib/PKCEHelper.php
+++ b/lib/PKCEHelper.php
@@ -75,7 +75,7 @@ class PKCEHelper
      * Generate an AuthKit authorization URL with auto-generated PKCE parameters and state.
      *
      * @param string $redirectUri The redirect URI.
-     * @param string $clientId The WorkOS client ID.
+     * @param string|null $clientId The WorkOS client ID. Defaults to the client's configured client ID.
      * @param string|null $state Optional state parameter. Auto-generated if null.
      * @param string|null $provider Optional auth provider.
      * @param string|null $connectionId Optional connection ID.
@@ -87,7 +87,7 @@ class PKCEHelper
      */
     public function getAuthKitAuthorizationUrl(
         string $redirectUri,
-        string $clientId,
+        ?string $clientId = null,
         ?string $state = null,
         ?string $provider = null,
         ?string $connectionId = null,
@@ -96,6 +96,7 @@ class PKCEHelper
         ?string $loginHint = null,
         ?string $screenHint = null,
     ): array {
+        $clientId ??= $this->client->requireClientId();
         $pkce = self::generate();
         $state ??= bin2hex(random_bytes(16));
 
@@ -134,14 +135,16 @@ class PKCEHelper
      *
      * @param string $code The authorization code.
      * @param string $codeVerifier The PKCE code verifier.
-     * @param string $clientId The WorkOS client ID.
+     * @param string|null $clientId The WorkOS client ID. Defaults to the client's configured client ID.
      * @return array The authentication response.
      */
     public function authKitCodeExchange(
         string $code,
         string $codeVerifier,
-        string $clientId,
+        ?string $clientId = null,
     ): array {
+        $clientId ??= $this->client->requireClientId();
+
         return $this->client->request(
             method: 'POST',
             path: 'user_management/authenticate',
@@ -160,7 +163,7 @@ class PKCEHelper
      * Generate an SSO authorization URL with auto-generated PKCE parameters and state.
      *
      * @param string $redirectUri The redirect URI.
-     * @param string $clientId The WorkOS client ID.
+     * @param string|null $clientId The WorkOS client ID. Defaults to the client's configured client ID.
      * @param string|null $state Optional state parameter. Auto-generated if null.
      * @param string|null $domain Optional SSO domain.
      * @param string|null $provider Optional SSO provider.
@@ -172,7 +175,7 @@ class PKCEHelper
      */
     public function getSsoAuthorizationUrl(
         string $redirectUri,
-        string $clientId,
+        ?string $clientId = null,
         ?string $state = null,
         ?string $domain = null,
         ?string $provider = null,
@@ -181,6 +184,7 @@ class PKCEHelper
         ?string $domainHint = null,
         ?string $loginHint = null,
     ): array {
+        $clientId ??= $this->client->requireClientId();
         $pkce = self::generate();
         $state ??= bin2hex(random_bytes(16));
 
@@ -219,14 +223,16 @@ class PKCEHelper
      *
      * @param string $code The authorization code.
      * @param string $codeVerifier The PKCE code verifier.
-     * @param string $clientId The WorkOS client ID.
+     * @param string|null $clientId The WorkOS client ID. Defaults to the client's configured client ID.
      * @return array The SSO token response.
      */
     public function ssoCodeExchange(
         string $code,
         string $codeVerifier,
-        string $clientId,
+        ?string $clientId = null,
     ): array {
+        $clientId ??= $this->client->requireClientId();
+
         return $this->client->request(
             method: 'POST',
             path: 'sso/token',

--- a/tests/PKCEHelperTest.php
+++ b/tests/PKCEHelperTest.php
@@ -86,6 +86,41 @@ class PKCEHelperTest extends TestCase
         $this->assertSame('S256', $query['code_challenge_method']);
     }
 
+    public function testGetAuthKitAuthorizationUrlFallsBackToConfiguredClientId(): void
+    {
+        $client = $this->createMockClient([['status' => 200, 'body' => ['url' => 'https://auth.workos.com/...']]]);
+        $client->pkce()->getAuthKitAuthorizationUrl(
+            redirectUri: 'https://example.com/callback',
+        );
+        $query = [];
+        parse_str($this->getLastRequest()->getUri()->getQuery(), $query);
+        $this->assertSame('test_client_id', $query['client_id']);
+    }
+
+    public function testGetAuthKitAuthorizationUrlExplicitClientIdWins(): void
+    {
+        $client = $this->createMockClient([['status' => 200, 'body' => ['url' => 'https://auth.workos.com/...']]]);
+        $client->pkce()->getAuthKitAuthorizationUrl(
+            redirectUri: 'https://example.com/callback',
+            clientId: 'client_override',
+        );
+        $query = [];
+        parse_str($this->getLastRequest()->getUri()->getQuery(), $query);
+        $this->assertSame('client_override', $query['client_id']);
+    }
+
+    public function testGetAuthKitAuthorizationUrlThrowsWithoutAnyClientId(): void
+    {
+        $client = $this->createMockClient(
+            [['status' => 200, 'body' => []]],
+            clientId: null,
+        );
+        $this->expectException(\WorkOS\Exception\ConfigurationException::class);
+        $client->pkce()->getAuthKitAuthorizationUrl(
+            redirectUri: 'https://example.com/callback',
+        );
+    }
+
     // -- H11: AuthKit PKCE code exchange --
 
     public function testAuthKitCodeExchange(): void
@@ -103,6 +138,17 @@ class PKCEHelperTest extends TestCase
         $body = json_decode((string) $request->getBody(), true);
         $this->assertSame('authorization_code', $body['grant_type']);
         $this->assertSame('verifier_123', $body['code_verifier']);
+    }
+
+    public function testAuthKitCodeExchangeFallsBackToConfiguredClientId(): void
+    {
+        $client = $this->createMockClient([['status' => 200, 'body' => ['access_token' => 'at_123']]]);
+        $client->pkce()->authKitCodeExchange(
+            code: 'auth_code_123',
+            codeVerifier: 'verifier_123',
+        );
+        $body = json_decode((string) $this->getLastRequest()->getBody(), true);
+        $this->assertSame('test_client_id', $body['client_id']);
     }
 
     // -- H15: SSO PKCE authorization URL --


### PR DESCRIPTION
## Summary

- Fail closed after signature verification when `exp` is missing, null, or non-numeric, preventing signed session tokens from bypassing expiration checks.
- Reject expired tokens, including the exact `exp == time()` boundary, while preserving numeric-string compatibility.
- Cover 15 expiration cases with signed JWTs and an isolated, deterministic test clock; invalid tokens retain the public `invalid_jwt` response.
- Keep this fix exp-only: `iss`/`aud`/`nbf` validation is intentionally deferred. Issuer validation is tracked separately in #440, and the existing issuer/audience TODO remains unchanged.

## Validation

`composer ci` passes: PHP-CS-Fixer reports 0 fixable files, PHPStan reports 0 errors, and PHPUnit reports 366 tests and 1,708 assertions. The two original missing-fixture skips are pre-existing and unrelated; current `main` adds a third (`OrganizationsTest::testListItContacts`). All 15 expiration cases pass.

Current `main` was merged without conflicts to exclude an inherited, already-merged PKCE change from the PR diff. Only `lib/SessionManager.php`, `tests/SessionManagerTest.php`, and `tests/Fixtures/session_expiration_clock.php` differ from `main`.
